### PR TITLE
docs: fix Option 2 wording and add Option 3 for Pkg.add

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The shared library is installed to:
 /path/to/Tensor4all.jl/deps/libtensor4all_capi.{dylib,so,dll}
 ```
 
-### Option 2: Add from another environment or global
+### Option 2: Develop from another environment or global
 
 ```julia
 using Pkg
@@ -46,6 +46,19 @@ The shared library is installed to:
 /path/to/Tensor4all.jl/deps/libtensor4all_capi.{dylib,so,dll}
 ```
 (Same location as the source — `Pkg.develop` symlinks to the local directory.)
+
+### Option 3: Add from another environment (e.g., from GitHub URL)
+
+```julia
+using Pkg
+Pkg.add(url="https://github.com/tensor4all/Tensor4all.jl.git")
+Pkg.build("Tensor4all")  # Automatically compiles the Rust backend
+```
+
+The shared library is installed to:
+```
+~/.julia/packages/Tensor4all/<hash>/deps/libtensor4all_capi.{dylib,so,dll}
+```
 
 ### Rust source resolution
 


### PR DESCRIPTION
## Summary
- Rename Option 2 from "Add" to "Develop" to correctly reflect the `Pkg.develop` command used
- Add Option 3 documenting `Pkg.add(url=...)` for users installing from another environment, with the verified library path (`~/.julia/packages/Tensor4all/<hash>/deps/`)

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)