### PR TITLE
chore(ci): bump actions/checkout v4→v6 and codecov/codecov-action v4→v5

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,7 +29,7 @@ jobs:
             coverage: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: julia-actions/setup-julia@v2
         with:
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload coverage
         if: matrix.coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from v4 to v6
- Bump `codecov/codecov-action` from v4 to v5
- Supersedes #3 and #4 (dependabot PRs that were stale or failing due to outdated base)

## Notes
- PR #3 (`actions/checkout` v5→v6) was based on an older branch that already had v5, but main has v4
- PR #4 (`codecov/codecov-action` v4→v5) was failing CI because its branch was based on old CI.yml

Once this PR is merged, #3 and #4 should be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)