### PR TITLE
[codex] combine GitHub Actions dependency bumps from #23 and #24

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
 
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
 
       - name: Checkout tensor4all-rs backend
         run: |
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload coverage
         if: matrix.coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Checkout tensor4all-rs backend
         run: |
           git clone https://github.com/tensor4all/tensor4all-rs.git ../tensor4all-rs
-          git -C ../tensor4all-rs checkout 8fa020da90a8dae133bf6894c2dc7230b1981643
+          git -C ../tensor4all-rs checkout 7082baa0a56873758aec75d846f67a1b44825348
 
       # HDF5 is loaded at runtime from HDF5.jl (no system installation needed)
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           version: "1.11"
 
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
 
       - name: Checkout tensor4all-rs backend
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout tensor4all-rs backend
         run: |
           git clone https://github.com/tensor4all/tensor4all-rs.git ../tensor4all-rs
-          git -C ../tensor4all-rs checkout 8fa020da90a8dae133bf6894c2dc7230b1981643
+          git -C ../tensor4all-rs checkout 7082baa0a56873758aec75d846f67a1b44825348
 
       - name: Install package and build documentation
         env:


### PR DESCRIPTION
## Summary
- bump `codecov/codecov-action` from `v5` to `v6` in CI
- bump `julia-actions/cache` from `v2` to `v3` in CI and docs workflows
- update the `tensor4all-rs` Actions pin to reachable upstream commit `7082baa0a56873758aec75d846f67a1b44825348` from merged PR #414
- consolidate the separate Dependabot updates from #23 and #24 into one branch and fix the resulting CI breakage

## Validation
- `git diff --check`
- verified a fresh `tensor4all-rs` `main` clone resolves to `7082baa0a56873758aec75d846f67a1b44825348`
- confirmed GitHub Actions checks on this PR completed successfully

## Notes
- This PR supersedes #23 and #24.