### PR TITLE
feat: Phase 1 migration APIs — SVD, QR, orthogonalize, truncate, queries, QuanticsTransform materialization

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Checkout tensor4all-rs backend
         run: |
           git clone https://github.com/tensor4all/tensor4all-rs.git ../tensor4all-rs
-          git -C ../tensor4all-rs checkout 7fb47f9b6955af04e919251edac7c68e24b75be5
+          git -C ../tensor4all-rs checkout 5082acabf3bb7da033ef4cb4ee27fbcfcb2dcd65
 
       # HDF5 is loaded at runtime from HDF5.jl (no system installation needed)
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -12,7 +12,7 @@ using Libdl
 using RustToolChain: cargo
 
 # Configuration
-const TENSOR4ALL_RS_FALLBACK_COMMIT = "7fb47f9b6955af04e919251edac7c68e24b75be5"
+const TENSOR4ALL_RS_FALLBACK_COMMIT = "5082acabf3bb7da033ef4cb4ee27fbcfcb2dcd65"
 const TENSOR4ALL_RS_REPO = "https://github.com/tensor4all/tensor4all-rs.git"
 
 # Paths

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -13,8 +13,12 @@
 - `Tensor4all.commoninds`, `Tensor4all.uniqueinds`
 - `Tensor4all.inds`, `Tensor4all.rank`, `Tensor4all.dims`,
   `Tensor4all.swapinds`
-- `Tensor4all.contract` — **not yet implemented**; calling this will raise
-  `SkeletonNotImplemented`
+- `Tensor4all.dag` — pure Julia tensor conjugation
+- `Array(t, inds...)` — dense tensor extraction in the requested index order
+- `Tensor4all.contract` — backend tensor contraction via the
+  `t4a_tensor_contract` C API
+- `Tensor4all.svd`, `Tensor4all.qr` — backend tensor factorizations via the
+  C API
 
 ```@docs
 Tensor4all
@@ -59,6 +63,15 @@ Other chain-facing names in this layer include:
 - `Tensor4all.TensorNetworks.matchsiteinds`
 - `Tensor4all.TensorNetworks.save_as_mps`
 - `Tensor4all.TensorNetworks.load_tt`
+- `Tensor4all.TensorNetworks.dag`
+- `Tensor4all.TensorNetworks.linkinds`
+- `Tensor4all.TensorNetworks.linkdims`
+- `Tensor4all.TensorNetworks.siteinds`
+- `Tensor4all.TensorNetworks.orthogonalize`
+- `Tensor4all.TensorNetworks.truncate`
+- `Tensor4all.TensorNetworks.add`
+- `Tensor4all.TensorNetworks.dot`, `Tensor4all.TensorNetworks.inner`
+- `Tensor4all.TensorNetworks.dist`
 
 `TensorNetworks.TensorTrain` is the container that HDF5 compatibility works
 against.
@@ -66,7 +79,9 @@ against.
 The current Julia implementation includes the full helper surface above.
 `set_input_space!`, `set_output_space!`, and `set_iospaces!` accept explicit
 `Vector{Index}` arguments only. `apply` is implemented for the current
-chain-oriented backend path.
+chain-oriented backend path. `TensorTrain` also supports scalar arithmetic and
+comparison on the current backend path through `+`, `-`, scalar `*`, scalar
+`/`, `norm`, `dot`/`inner`, `isapprox`, `dist`, and `add`.
 
 ```@autodocs
 Modules = [Tensor4all.TensorNetworks]
@@ -137,13 +152,19 @@ Order = [:type, :function]
 These constructors return `TensorNetworks.LinearOperator` values. The generic
 operator type itself does not live in `QuanticsTransform`.
 
-In the current branch these constructors are metadata-only descriptions of the
-requested quantics operator. Real operator execution remains owned by
-`TensorNetworks.apply`.
+In the current branch, `shift_operator`, `shift_operator_multivar`,
+`flip_operator`, `flip_operator_multivar`, `phase_rotation_operator`,
+`phase_rotation_operator_multivar`, `cumsum_operator`, `fourier_operator`, and
+`affine_operator` materialize real MPO-backed operators through the C API.
+`TensorNetworks.apply` owns execution of those materialized operators once the
+I/O spaces are bound.
+
+`affine_pullback_operator` and `binaryop_operator` remain deferred
+metadata-only placeholders in this phase.
 
 ```@autodocs
 Modules = [Tensor4all.QuanticsTransform]
-Pages = ["QuanticsTransform.jl"]
+Pages = ["QuanticsTransform/QuanticsTransform.jl", "QuanticsTransform/operators.jl"]
 Private = false
 Order = [:function]
 ```

--- a/src/Core/Tensor.jl
+++ b/src/Core/Tensor.jl
@@ -1,5 +1,5 @@
 import Base: +, -, *, /
-import LinearAlgebra: norm
+import LinearAlgebra: norm, qr, svd
 
 """
     Tensor(data, inds; backend_handle=nothing)
@@ -81,6 +81,13 @@ function prime(t::Tensor, n::Integer=1)
 end
 
 """
+    dag(t)
+
+Return the elementwise complex-conjugated tensor with the same index metadata.
+"""
+dag(t::Tensor) = Tensor(conj(t.data), inds(t); backend_handle=nothing)
+
+"""
     swapinds(t, a, b)
 
 Swap index metadata `a` and `b` on `t`.
@@ -151,6 +158,11 @@ function Base.isapprox(
     return isapprox(a.data, b_data; atol=atol, rtol=rtol)
 end
 
+function Base.Array(t::Tensor, requested_inds::Index...)
+    perm = _match_index_permutation(inds(t), collect(requested_inds))
+    return perm == Tuple(1:rank(t)) ? copy(t.data) : permutedims(t.data, perm)
+end
+
 function _tensor_scalar_kind(tensors::Tensor...)
     any_complex = false
     for tensor in tensors
@@ -167,6 +179,29 @@ function _tensor_scalar_kind(tensors::Tensor...)
 end
 
 _tensor_networks_module() = getfield(@__MODULE__, :TensorNetworks)
+
+function _validate_tensor_left_inds(t::Tensor, left_inds::Vector{Index})
+    isempty(left_inds) && throw(ArgumentError("left_inds must not be empty"))
+    length(unique(left_inds)) == length(left_inds) || throw(
+        ArgumentError("left_inds must not contain duplicates, got $left_inds"),
+    )
+
+    tensor_inds = inds(t)
+    for idx in left_inds
+        idx in tensor_inds || throw(
+            ArgumentError("Index $idx not found in tensor indices $tensor_inds"),
+        )
+    end
+    length(left_inds) == rank(t) && throw(ArgumentError("left_inds must not contain all indices"))
+    return tensor_inds
+end
+
+function _validate_truncation_controls(; rtol::Real=0.0, cutoff::Real=0.0, maxdim::Integer=0)
+    rtol >= 0 || throw(ArgumentError("rtol must be nonnegative, got $rtol"))
+    cutoff >= 0 || throw(ArgumentError("cutoff must be nonnegative, got $cutoff"))
+    maxdim >= 0 || throw(ArgumentError("maxdim must be nonnegative, got $maxdim"))
+    return nothing
+end
 
 """
     contract(a, b)
@@ -205,3 +240,139 @@ function contract(a::Tensor, b::Tensor)
         tn._release_tensor_handle(a_handle)
     end
 end
+
+"""
+    svd(t, left_inds; rtol=0.0, cutoff=0.0, maxdim=0)
+
+Compute a backend SVD of `t`, grouping `left_inds` as the left partition.
+"""
+function svd(
+    t::Tensor,
+    left_inds::Vector{Index};
+    rtol::Real=0.0,
+    cutoff::Real=0.0,
+    maxdim::Integer=0,
+)
+    _validate_tensor_left_inds(t, left_inds)
+    _validate_truncation_controls(; rtol, cutoff, maxdim)
+
+    scalar_kind = _tensor_scalar_kind(t)
+    tn = _tensor_networks_module()
+    t_handle = C_NULL
+    left_handles = Ptr{Cvoid}[]
+    u_handle = C_NULL
+    s_handle = C_NULL
+    v_handle = C_NULL
+
+    try
+        t_handle = tn._new_tensor_handle(t, scalar_kind)
+        for idx in left_inds
+            push!(left_handles, tn._new_index_handle(idx))
+        end
+
+        out_u = Ref{Ptr{Cvoid}}(C_NULL)
+        out_s = Ref{Ptr{Cvoid}}(C_NULL)
+        out_v = Ref{Ptr{Cvoid}}(C_NULL)
+        status = ccall(
+            tn._t4a(:t4a_tensor_svd),
+            Cint,
+            (
+                Ptr{Cvoid},
+                Ptr{Ptr{Cvoid}},
+                Csize_t,
+                Cdouble,
+                Cdouble,
+                Csize_t,
+                Ref{Ptr{Cvoid}},
+                Ref{Ptr{Cvoid}},
+                Ref{Ptr{Cvoid}},
+            ),
+            t_handle,
+            left_handles,
+            Csize_t(length(left_handles)),
+            float(rtol),
+            float(cutoff),
+            Csize_t(maxdim),
+            out_u,
+            out_s,
+            out_v,
+        )
+        tn._check_backend_status(status, "computing tensor SVD")
+        u_handle = out_u[]
+        s_handle = out_s[]
+        v_handle = out_v[]
+        u = tn._tensor_from_handle(u_handle)
+        s = tn._tensor_from_handle(s_handle)
+        v = tn._tensor_from_handle(v_handle)
+
+        # Align V's surviving bond index with S so U * S * dag(V) reconstructs.
+        v_inds = inds(v)
+        s_inds = inds(s)
+        v = Tensor(
+            copy(v.data),
+            replaceind(v_inds, last(v_inds), last(s_inds));
+            backend_handle=v.backend_handle,
+        )
+        return (u, s, v)
+    finally
+        tn._release_tensor_handle(v_handle)
+        tn._release_tensor_handle(s_handle)
+        tn._release_tensor_handle(u_handle)
+        for handle in reverse(left_handles)
+            tn._release_index_handle(handle)
+        end
+        tn._release_tensor_handle(t_handle)
+    end
+end
+
+svd(t::Tensor, left_inds::Index...; kwargs...) = svd(t, collect(left_inds); kwargs...)
+
+"""
+    qr(t, left_inds)
+
+Compute a backend QR decomposition of `t`, grouping `left_inds` as the left
+partition.
+"""
+function qr(t::Tensor, left_inds::Vector{Index})
+    _validate_tensor_left_inds(t, left_inds)
+
+    scalar_kind = _tensor_scalar_kind(t)
+    tn = _tensor_networks_module()
+    t_handle = C_NULL
+    left_handles = Ptr{Cvoid}[]
+    q_handle = C_NULL
+    r_handle = C_NULL
+
+    try
+        t_handle = tn._new_tensor_handle(t, scalar_kind)
+        for idx in left_inds
+            push!(left_handles, tn._new_index_handle(idx))
+        end
+
+        out_q = Ref{Ptr{Cvoid}}(C_NULL)
+        out_r = Ref{Ptr{Cvoid}}(C_NULL)
+        status = ccall(
+            tn._t4a(:t4a_tensor_qr),
+            Cint,
+            (Ptr{Cvoid}, Ptr{Ptr{Cvoid}}, Csize_t, Ref{Ptr{Cvoid}}, Ref{Ptr{Cvoid}}),
+            t_handle,
+            left_handles,
+            Csize_t(length(left_handles)),
+            out_q,
+            out_r,
+        )
+        tn._check_backend_status(status, "computing tensor QR")
+        q_handle = out_q[]
+        r_handle = out_r[]
+        return (tn._tensor_from_handle(q_handle), tn._tensor_from_handle(r_handle))
+    finally
+        tn._release_tensor_handle(r_handle)
+        tn._release_tensor_handle(q_handle)
+        for handle in reverse(left_handles)
+            tn._release_index_handle(handle)
+        end
+        tn._release_tensor_handle(t_handle)
+    end
+end
+
+qr(t::Tensor, left_inds::Index...) = qr(t, collect(left_inds))

--- a/src/QuanticsTransform.jl
+++ b/src/QuanticsTransform.jl
@@ -10,90 +10,403 @@ export affine_operator, affine_pullback_operator, binaryop_operator
 
 _placeholder_operator(kind::Symbol; kwargs...) = TensorNetworks.LinearOperator(metadata=(; kind, kwargs...))
 
+function _require_positive_integer(name::AbstractString, value::Integer)
+    value > 0 || throw(ArgumentError("$name must be positive, got $value"))
+    return value
+end
+
+function _require_multivar_target(nvars::Integer, target::Integer)
+    _require_positive_integer("nvars", nvars)
+    1 <= target <= nvars || throw(
+        ArgumentError("target must be between 1 and $nvars, got $target"),
+    )
+    return target
+end
+
+function _require_nonnegative_integer(name::AbstractString, value::Integer)
+    value >= 0 || throw(ArgumentError("$name must be nonnegative, got $value"))
+    return value
+end
+
+function _require_nonnegative_real(name::AbstractString, value::Real)
+    value >= 0 || throw(ArgumentError("$name must be nonnegative, got $value"))
+    return value
+end
+
+function _require_nonzero_integer(name::AbstractString, value)
+    value == 0 && throw(ArgumentError("$name must be nonzero, got $value"))
+    return value
+end
+
+function _materialized_linear_operator(treetn_handle::Ptr{Cvoid})
+    try
+        tt = TensorNetworks._treetn_from_handle(treetn_handle)
+        input_indices, output_indices = TensorNetworks._extract_mpo_io_indices(tt)
+        return TensorNetworks.LinearOperator(;
+            mpo=tt,
+            input_indices=input_indices,
+            output_indices=output_indices,
+        )
+    finally
+        TensorNetworks._release_treetn_handle(treetn_handle)
+    end
+end
+
+function _new_univariate_layout(r::Integer)
+    _require_positive_integer("r", r)
+    return TensorNetworks._new_qtt_layout_handle(1, [r])
+end
+
+function _new_multivar_layout(r::Integer, nvars::Integer)
+    _require_positive_integer("r", r)
+    _require_positive_integer("nvars", nvars)
+    return TensorNetworks._new_qtt_layout_handle(nvars, fill(r, nvars))
+end
+
+function _materialize_shift(
+    layout_handle::Ptr{Cvoid},
+    target_var::Integer,
+    offset::Integer,
+    bc::Symbol,
+    context::AbstractString,
+)
+    out = Ref{Ptr{Cvoid}}(C_NULL)
+    status = ccall(
+        TensorNetworks._t4a(:t4a_qtransform_shift_materialize),
+        Cint,
+        (Ptr{Cvoid}, Csize_t, Int64, Cint, Ref{Ptr{Cvoid}}),
+        layout_handle,
+        Csize_t(target_var),
+        Int64(offset),
+        TensorNetworks._bc_code(bc),
+        out,
+    )
+    TensorNetworks._check_backend_status(status, context)
+    return _materialized_linear_operator(out[])
+end
+
+function _materialize_flip(
+    layout_handle::Ptr{Cvoid},
+    target_var::Integer,
+    bc::Symbol,
+    context::AbstractString,
+)
+    out = Ref{Ptr{Cvoid}}(C_NULL)
+    status = ccall(
+        TensorNetworks._t4a(:t4a_qtransform_flip_materialize),
+        Cint,
+        (Ptr{Cvoid}, Csize_t, Cint, Ref{Ptr{Cvoid}}),
+        layout_handle,
+        Csize_t(target_var),
+        TensorNetworks._bc_code(bc),
+        out,
+    )
+    TensorNetworks._check_backend_status(status, context)
+    return _materialized_linear_operator(out[])
+end
+
+function _materialize_phase_rotation(
+    layout_handle::Ptr{Cvoid},
+    target_var::Integer,
+    theta,
+    context::AbstractString,
+)
+    out = Ref{Ptr{Cvoid}}(C_NULL)
+    status = ccall(
+        TensorNetworks._t4a(:t4a_qtransform_phase_rotation_materialize),
+        Cint,
+        (Ptr{Cvoid}, Csize_t, Cdouble, Ref{Ptr{Cvoid}}),
+        layout_handle,
+        Csize_t(target_var),
+        Float64(theta),
+        out,
+    )
+    TensorNetworks._check_backend_status(status, context)
+    return _materialized_linear_operator(out[])
+end
+
+function _materialize_cumsum(
+    layout_handle::Ptr{Cvoid},
+    target_var::Integer,
+    context::AbstractString,
+)
+    out = Ref{Ptr{Cvoid}}(C_NULL)
+    status = ccall(
+        TensorNetworks._t4a(:t4a_qtransform_cumsum_materialize),
+        Cint,
+        (Ptr{Cvoid}, Csize_t, Ref{Ptr{Cvoid}}),
+        layout_handle,
+        Csize_t(target_var),
+        out,
+    )
+    TensorNetworks._check_backend_status(status, context)
+    return _materialized_linear_operator(out[])
+end
+
+function _materialize_fourier(
+    layout_handle::Ptr{Cvoid},
+    target_var::Integer,
+    forward::Bool,
+    maxbonddim::Integer,
+    tolerance::Real,
+    context::AbstractString,
+)
+    _require_nonnegative_integer("maxbonddim", maxbonddim)
+    _require_nonnegative_real("tolerance", tolerance)
+
+    out = Ref{Ptr{Cvoid}}(C_NULL)
+    status = ccall(
+        TensorNetworks._t4a(:t4a_qtransform_fourier_materialize),
+        Cint,
+        (Ptr{Cvoid}, Csize_t, Int32, Csize_t, Cdouble, Ref{Ptr{Cvoid}}),
+        layout_handle,
+        Csize_t(target_var),
+        Int32(forward),
+        Csize_t(maxbonddim),
+        Float64(tolerance),
+        out,
+    )
+    TensorNetworks._check_backend_status(status, context)
+    return _materialized_linear_operator(out[])
+end
+
+function _materialize_affine(
+    layout_handle::Ptr{Cvoid},
+    a_num,
+    a_den,
+    b_num,
+    b_den,
+    bc::Symbol,
+    context::AbstractString,
+)
+    _require_nonzero_integer("a_den", a_den)
+    _require_nonzero_integer("b_den", b_den)
+
+    a_num_c = Int64[Int64(a_num)]
+    a_den_c = Int64[Int64(a_den)]
+    b_num_c = Int64[Int64(b_num)]
+    b_den_c = Int64[Int64(b_den)]
+    bc_c = Cint[TensorNetworks._bc_code(bc)]
+    out = Ref{Ptr{Cvoid}}(C_NULL)
+    status = ccall(
+        TensorNetworks._t4a(:t4a_qtransform_affine_materialize),
+        Cint,
+        (
+            Ptr{Cvoid},
+            Ptr{Int64},
+            Ptr{Int64},
+            Ptr{Int64},
+            Ptr{Int64},
+            Csize_t,
+            Csize_t,
+            Ptr{Cint},
+            Ref{Ptr{Cvoid}},
+        ),
+        layout_handle,
+        a_num_c,
+        a_den_c,
+        b_num_c,
+        b_den_c,
+        Csize_t(1),
+        Csize_t(1),
+        bc_c,
+        out,
+    )
+    TensorNetworks._check_backend_status(status, context)
+    return _materialized_linear_operator(out[])
+end
+
 """
     shift_operator(r, offset; bc=:periodic)
 
-Construct a metadata-only quantics shift operator description.
+Construct a quantics shift operator materialized as a `TensorNetworks.LinearOperator`.
 """
-shift_operator(r::Integer, offset::Integer; bc=:periodic) =
-    _placeholder_operator(:shift; r, offset, bc)
+function shift_operator(r::Integer, offset::Integer; bc=:periodic)
+    layout_handle = _new_univariate_layout(r)
+    try
+        return _materialize_shift(layout_handle, 0, offset, bc, "materializing shift operator")
+    finally
+        TensorNetworks._release_qtt_layout_handle(layout_handle)
+    end
+end
 
 """
     shift_operator_multivar(r, offset, nvars, target; bc=:periodic)
 
-Construct a metadata-only multivariable quantics shift operator description.
+Construct a multivariable quantics shift operator targeting the `target`th variable.
 """
-shift_operator_multivar(r::Integer, offset::Integer, nvars::Integer, target::Integer; bc=:periodic) =
-    _placeholder_operator(:shift_multivar; r, offset, nvars, target, bc)
+function shift_operator_multivar(
+    r::Integer,
+    offset::Integer,
+    nvars::Integer,
+    target::Integer;
+    bc=:periodic,
+)
+    _require_multivar_target(nvars, target)
+    layout_handle = _new_multivar_layout(r, nvars)
+    try
+        return _materialize_shift(
+            layout_handle,
+            target - 1,
+            offset,
+            bc,
+            "materializing multivar shift operator",
+        )
+    finally
+        TensorNetworks._release_qtt_layout_handle(layout_handle)
+    end
+end
 
 """
     flip_operator(r; bc=:periodic)
 
-Construct a metadata-only quantics flip operator description.
+Construct a quantics flip operator materialized as a `TensorNetworks.LinearOperator`.
 """
-flip_operator(r::Integer; bc=:periodic) =
-    _placeholder_operator(:flip; r, bc)
+function flip_operator(r::Integer; bc=:periodic)
+    layout_handle = _new_univariate_layout(r)
+    try
+        return _materialize_flip(layout_handle, 0, bc, "materializing flip operator")
+    finally
+        TensorNetworks._release_qtt_layout_handle(layout_handle)
+    end
+end
 
 """
     flip_operator_multivar(r, nvars, target; bc=:periodic)
 
-Construct a metadata-only multivariable quantics flip operator description.
+Construct a multivariable quantics flip operator targeting the `target`th variable.
 """
-flip_operator_multivar(r::Integer, nvars::Integer, target::Integer; bc=:periodic) =
-    _placeholder_operator(:flip_multivar; r, nvars, target, bc)
+function flip_operator_multivar(r::Integer, nvars::Integer, target::Integer; bc=:periodic)
+    _require_multivar_target(nvars, target)
+    layout_handle = _new_multivar_layout(r, nvars)
+    try
+        return _materialize_flip(
+            layout_handle,
+            target - 1,
+            bc,
+            "materializing multivar flip operator",
+        )
+    finally
+        TensorNetworks._release_qtt_layout_handle(layout_handle)
+    end
+end
 
 """
     phase_rotation_operator(r, theta)
 
-Construct a metadata-only quantics phase-rotation operator description.
+Construct a quantics phase-rotation operator materialized as a `TensorNetworks.LinearOperator`.
 """
-phase_rotation_operator(r::Integer, theta) =
-    _placeholder_operator(:phase_rotation; r, theta)
+function phase_rotation_operator(r::Integer, theta)
+    layout_handle = _new_univariate_layout(r)
+    try
+        return _materialize_phase_rotation(
+            layout_handle,
+            0,
+            theta,
+            "materializing phase rotation operator",
+        )
+    finally
+        TensorNetworks._release_qtt_layout_handle(layout_handle)
+    end
+end
 
 """
     phase_rotation_operator_multivar(r, theta, nvars, target)
 
-Construct a metadata-only multivariable phase-rotation operator description.
+Construct a multivariable phase-rotation operator targeting the `target`th variable.
 """
-phase_rotation_operator_multivar(r::Integer, theta, nvars::Integer, target::Integer) =
-    _placeholder_operator(:phase_rotation_multivar; r, theta, nvars, target)
+function phase_rotation_operator_multivar(r::Integer, theta, nvars::Integer, target::Integer)
+    _require_multivar_target(nvars, target)
+    layout_handle = _new_multivar_layout(r, nvars)
+    try
+        return _materialize_phase_rotation(
+            layout_handle,
+            target - 1,
+            theta,
+            "materializing multivar phase rotation operator",
+        )
+    finally
+        TensorNetworks._release_qtt_layout_handle(layout_handle)
+    end
+end
 
 """
     cumsum_operator(r)
 
-Construct a metadata-only quantics cumulative-sum operator description.
+Construct a quantics cumulative-sum operator materialized as a `TensorNetworks.LinearOperator`.
 """
-cumsum_operator(r::Integer) = _placeholder_operator(:cumsum; r)
+function cumsum_operator(r::Integer)
+    layout_handle = _new_univariate_layout(r)
+    try
+        return _materialize_cumsum(layout_handle, 0, "materializing cumsum operator")
+    finally
+        TensorNetworks._release_qtt_layout_handle(layout_handle)
+    end
+end
 
 """
     fourier_operator(r; forward=true, maxbonddim=typemax(Int), tolerance=0.0)
 
-Construct a metadata-only quantics Fourier operator description.
+Construct a quantics Fourier operator materialized as a `TensorNetworks.LinearOperator`.
 """
-fourier_operator(r::Integer; forward::Bool=true, maxbonddim::Int=typemax(Int), tolerance::Float64=0.0) =
-    _placeholder_operator(:fourier; r, forward, maxbonddim, tolerance)
+function fourier_operator(
+    r::Integer;
+    forward::Bool=true,
+    maxbonddim::Int=typemax(Int),
+    tolerance::Float64=0.0,
+)
+    layout_handle = _new_univariate_layout(r)
+    try
+        return _materialize_fourier(
+            layout_handle,
+            0,
+            forward,
+            maxbonddim,
+            tolerance,
+            "materializing Fourier operator",
+        )
+    finally
+        TensorNetworks._release_qtt_layout_handle(layout_handle)
+    end
+end
 
 """
     affine_operator(r, a_num, a_den, b_num, b_den; bc=:periodic)
 
-Construct a metadata-only quantics affine operator description.
+Construct a quantics affine operator materialized as a `TensorNetworks.LinearOperator`.
 """
-affine_operator(r::Integer, a_num, a_den, b_num, b_den; bc=:periodic) =
-    _placeholder_operator(:affine; r, a_num, a_den, b_num, b_den, bc)
+function affine_operator(r::Integer, a_num, a_den, b_num, b_den; bc=:periodic)
+    layout_handle = _new_univariate_layout(r)
+    try
+        return _materialize_affine(
+            layout_handle,
+            a_num,
+            a_den,
+            b_num,
+            b_den,
+            bc,
+            "materializing affine operator",
+        )
+    finally
+        TensorNetworks._release_qtt_layout_handle(layout_handle)
+    end
+end
 
 """
     affine_pullback_operator(r, params; bc=:periodic)
 
-Construct a metadata-only quantics affine-pullback operator description.
+Construct a metadata-only quantics affine-pullback operator placeholder.
 """
+# Deferred for the Phase 1 materialization pass.
 affine_pullback_operator(r::Integer, params; bc=:periodic) =
     _placeholder_operator(:affine_pullback; r, params, bc)
 
 """
     binaryop_operator(r, a1, b1, a2, b2; bc1=:periodic, bc2=:periodic)
 
-Construct a metadata-only quantics binary-operator description.
+Construct a metadata-only quantics binary-operator placeholder.
 """
+# Deferred for the Phase 1 materialization pass.
 binaryop_operator(r::Integer, a1, b1, a2, b2; bc1=:periodic, bc2=:periodic) =
     _placeholder_operator(:binaryop; r, a1, b1, a2, b2, bc1, bc2)
 

--- a/src/QuanticsTransform/QuanticsTransform.jl
+++ b/src/QuanticsTransform/QuanticsTransform.jl
@@ -1,0 +1,15 @@
+module QuanticsTransform
+
+import ..TensorNetworks
+using ..Tensor4all: Index
+
+export shift_operator, shift_operator_multivar
+export flip_operator, flip_operator_multivar
+export phase_rotation_operator, phase_rotation_operator_multivar
+export cumsum_operator, fourier_operator
+export affine_operator, affine_pullback_operator, binaryop_operator
+
+include("capi_helpers.jl")
+include("operators.jl")
+
+end

--- a/src/QuanticsTransform/capi_helpers.jl
+++ b/src/QuanticsTransform/capi_helpers.jl
@@ -1,0 +1,230 @@
+function _materialized_linear_operator(treetn_handle::Ptr{Cvoid})
+    try
+        tt = TensorNetworks._treetn_from_handle(treetn_handle)
+        input_indices, output_indices = _extract_mpo_io_indices(tt)
+        return TensorNetworks.LinearOperator(;
+            mpo=tt,
+            input_indices=input_indices,
+            output_indices=output_indices,
+        )
+    finally
+        TensorNetworks._release_treetn_handle(treetn_handle)
+    end
+end
+
+function _materialize_single_target(materialize::Function, context::AbstractString)
+    out = Ref{Ptr{Cvoid}}(C_NULL)
+    status = materialize(out)
+    TensorNetworks._check_backend_status(status, context)
+    return _materialized_linear_operator(out[])
+end
+
+function _bc_code(bc::Symbol)
+    bc === :periodic && return TensorNetworks._T4A_BC_PERIODIC
+    bc === :open && return TensorNetworks._T4A_BC_OPEN
+    throw(ArgumentError("unknown boundary condition $bc. Expected :periodic or :open"))
+end
+
+function _new_qtt_layout_handle(nvars::Integer, resolutions::Vector{<:Integer})
+    nvars > 0 || throw(ArgumentError("nvars must be positive, got $nvars"))
+    length(resolutions) == nvars || throw(
+        DimensionMismatch("expected $nvars variable resolutions, got $(length(resolutions))"),
+    )
+    all(>(0), resolutions) || throw(
+        ArgumentError("variable resolutions must all be positive, got $resolutions"),
+    )
+    length(unique(resolutions)) == 1 || throw(
+        ArgumentError("fused QTT layouts require all variable resolutions to match, got $resolutions"),
+    )
+
+    out = Ref{Ptr{Cvoid}}(C_NULL)
+    res_c = Csize_t[Csize_t(r) for r in resolutions]
+    status = ccall(
+        TensorNetworks._t4a(:t4a_qtt_layout_new),
+        Cint,
+        (Cint, Csize_t, Ptr{Csize_t}, Ref{Ptr{Cvoid}}),
+        TensorNetworks._T4A_QTT_LAYOUT_FUSED,
+        Csize_t(nvars),
+        res_c,
+        out,
+    )
+    TensorNetworks._check_backend_status(status, "creating QTT layout")
+    return out[]
+end
+
+function _release_qtt_layout_handle(ptr::Ptr{Cvoid})
+    ptr == C_NULL && return nothing
+    ccall(TensorNetworks._t4a(:t4a_qtt_layout_release), Cvoid, (Ptr{Cvoid},), ptr)
+    return nothing
+end
+
+function _new_univariate_layout(r::Integer)
+    _require_positive_integer("r", r)
+    return _new_qtt_layout_handle(1, [r])
+end
+
+function _new_multivar_layout(r::Integer, nvars::Integer)
+    _require_positive_integer("r", r)
+    _require_positive_integer("nvars", nvars)
+    return _new_qtt_layout_handle(nvars, fill(r, nvars))
+end
+
+function _extract_mpo_io_indices(tt::TensorNetworks.TensorTrain)
+    input_indices = Index[]
+    output_indices = Index[]
+    for site_inds in TensorNetworks.siteinds(tt)
+        length(site_inds) == 2 || throw(
+            ArgumentError("Expected 2 site indices per MPO tensor, got $(length(site_inds))"),
+        )
+        push!(output_indices, site_inds[1])
+        push!(input_indices, site_inds[2])
+    end
+    return input_indices, output_indices
+end
+
+function _materialize_shift(
+    layout_handle::Ptr{Cvoid},
+    target_var::Integer,
+    offset::Integer,
+    bc::Symbol,
+    context::AbstractString,
+)
+    return _materialize_single_target(context) do out
+        ccall(
+            TensorNetworks._t4a(:t4a_qtransform_shift_materialize),
+            Cint,
+            (Ptr{Cvoid}, Csize_t, Int64, Cint, Ref{Ptr{Cvoid}}),
+            layout_handle,
+            Csize_t(target_var),
+            Int64(offset),
+            _bc_code(bc),
+            out,
+        )
+    end
+end
+
+function _materialize_flip(
+    layout_handle::Ptr{Cvoid},
+    target_var::Integer,
+    bc::Symbol,
+    context::AbstractString,
+)
+    return _materialize_single_target(context) do out
+        ccall(
+            TensorNetworks._t4a(:t4a_qtransform_flip_materialize),
+            Cint,
+            (Ptr{Cvoid}, Csize_t, Cint, Ref{Ptr{Cvoid}}),
+            layout_handle,
+            Csize_t(target_var),
+            _bc_code(bc),
+            out,
+        )
+    end
+end
+
+function _materialize_phase_rotation(
+    layout_handle::Ptr{Cvoid},
+    target_var::Integer,
+    theta,
+    context::AbstractString,
+)
+    return _materialize_single_target(context) do out
+        ccall(
+            TensorNetworks._t4a(:t4a_qtransform_phase_rotation_materialize),
+            Cint,
+            (Ptr{Cvoid}, Csize_t, Cdouble, Ref{Ptr{Cvoid}}),
+            layout_handle,
+            Csize_t(target_var),
+            Float64(theta),
+            out,
+        )
+    end
+end
+
+function _materialize_cumsum(
+    layout_handle::Ptr{Cvoid},
+    target_var::Integer,
+    context::AbstractString,
+)
+    return _materialize_single_target(context) do out
+        ccall(
+            TensorNetworks._t4a(:t4a_qtransform_cumsum_materialize),
+            Cint,
+            (Ptr{Cvoid}, Csize_t, Ref{Ptr{Cvoid}}),
+            layout_handle,
+            Csize_t(target_var),
+            out,
+        )
+    end
+end
+
+function _materialize_fourier(
+    layout_handle::Ptr{Cvoid},
+    target_var::Integer,
+    forward::Bool,
+    maxbonddim::Integer,
+    tolerance::Real,
+    context::AbstractString,
+)
+    _require_nonnegative_integer("maxbonddim", maxbonddim)
+    _require_nonnegative_real("tolerance", tolerance)
+
+    return _materialize_single_target(context) do out
+        ccall(
+            TensorNetworks._t4a(:t4a_qtransform_fourier_materialize),
+            Cint,
+            (Ptr{Cvoid}, Csize_t, Int32, Csize_t, Cdouble, Ref{Ptr{Cvoid}}),
+            layout_handle,
+            Csize_t(target_var),
+            Int32(forward),
+            Csize_t(maxbonddim),
+            Float64(tolerance),
+            out,
+        )
+    end
+end
+
+function _materialize_affine(
+    layout_handle::Ptr{Cvoid},
+    a_num,
+    a_den,
+    b_num,
+    b_den,
+    bc::Symbol,
+    context::AbstractString,
+)
+    _require_nonzero_integer("a_den", a_den)
+    _require_nonzero_integer("b_den", b_den)
+
+    a_num_c = Int64[Int64(a_num)]
+    a_den_c = Int64[Int64(a_den)]
+    b_num_c = Int64[Int64(b_num)]
+    b_den_c = Int64[Int64(b_den)]
+    bc_c = Cint[_bc_code(bc)]
+    return _materialize_single_target(context) do out
+        ccall(
+            TensorNetworks._t4a(:t4a_qtransform_affine_materialize),
+            Cint,
+            (
+                Ptr{Cvoid},
+                Ptr{Int64},
+                Ptr{Int64},
+                Ptr{Int64},
+                Ptr{Int64},
+                Csize_t,
+                Csize_t,
+                Ptr{Cint},
+                Ref{Ptr{Cvoid}},
+            ),
+            layout_handle,
+            a_num_c,
+            a_den_c,
+            b_num_c,
+            b_den_c,
+            Csize_t(1),
+            Csize_t(1),
+            bc_c,
+            out,
+        )
+    end
+end

--- a/src/QuanticsTransform/operators.jl
+++ b/src/QuanticsTransform/operators.jl
@@ -1,13 +1,3 @@
-module QuanticsTransform
-
-import ..TensorNetworks
-
-export shift_operator, shift_operator_multivar
-export flip_operator, flip_operator_multivar
-export phase_rotation_operator, phase_rotation_operator_multivar
-export cumsum_operator, fourier_operator
-export affine_operator, affine_pullback_operator, binaryop_operator
-
 _placeholder_operator(kind::Symbol; kwargs...) = TensorNetworks.LinearOperator(metadata=(; kind, kwargs...))
 
 function _require_positive_integer(name::AbstractString, value::Integer)
@@ -38,184 +28,6 @@ function _require_nonzero_integer(name::AbstractString, value)
     return value
 end
 
-function _materialized_linear_operator(treetn_handle::Ptr{Cvoid})
-    try
-        tt = TensorNetworks._treetn_from_handle(treetn_handle)
-        input_indices, output_indices = TensorNetworks._extract_mpo_io_indices(tt)
-        return TensorNetworks.LinearOperator(;
-            mpo=tt,
-            input_indices=input_indices,
-            output_indices=output_indices,
-        )
-    finally
-        TensorNetworks._release_treetn_handle(treetn_handle)
-    end
-end
-
-function _new_univariate_layout(r::Integer)
-    _require_positive_integer("r", r)
-    return TensorNetworks._new_qtt_layout_handle(1, [r])
-end
-
-function _new_multivar_layout(r::Integer, nvars::Integer)
-    _require_positive_integer("r", r)
-    _require_positive_integer("nvars", nvars)
-    return TensorNetworks._new_qtt_layout_handle(nvars, fill(r, nvars))
-end
-
-function _materialize_shift(
-    layout_handle::Ptr{Cvoid},
-    target_var::Integer,
-    offset::Integer,
-    bc::Symbol,
-    context::AbstractString,
-)
-    out = Ref{Ptr{Cvoid}}(C_NULL)
-    status = ccall(
-        TensorNetworks._t4a(:t4a_qtransform_shift_materialize),
-        Cint,
-        (Ptr{Cvoid}, Csize_t, Int64, Cint, Ref{Ptr{Cvoid}}),
-        layout_handle,
-        Csize_t(target_var),
-        Int64(offset),
-        TensorNetworks._bc_code(bc),
-        out,
-    )
-    TensorNetworks._check_backend_status(status, context)
-    return _materialized_linear_operator(out[])
-end
-
-function _materialize_flip(
-    layout_handle::Ptr{Cvoid},
-    target_var::Integer,
-    bc::Symbol,
-    context::AbstractString,
-)
-    out = Ref{Ptr{Cvoid}}(C_NULL)
-    status = ccall(
-        TensorNetworks._t4a(:t4a_qtransform_flip_materialize),
-        Cint,
-        (Ptr{Cvoid}, Csize_t, Cint, Ref{Ptr{Cvoid}}),
-        layout_handle,
-        Csize_t(target_var),
-        TensorNetworks._bc_code(bc),
-        out,
-    )
-    TensorNetworks._check_backend_status(status, context)
-    return _materialized_linear_operator(out[])
-end
-
-function _materialize_phase_rotation(
-    layout_handle::Ptr{Cvoid},
-    target_var::Integer,
-    theta,
-    context::AbstractString,
-)
-    out = Ref{Ptr{Cvoid}}(C_NULL)
-    status = ccall(
-        TensorNetworks._t4a(:t4a_qtransform_phase_rotation_materialize),
-        Cint,
-        (Ptr{Cvoid}, Csize_t, Cdouble, Ref{Ptr{Cvoid}}),
-        layout_handle,
-        Csize_t(target_var),
-        Float64(theta),
-        out,
-    )
-    TensorNetworks._check_backend_status(status, context)
-    return _materialized_linear_operator(out[])
-end
-
-function _materialize_cumsum(
-    layout_handle::Ptr{Cvoid},
-    target_var::Integer,
-    context::AbstractString,
-)
-    out = Ref{Ptr{Cvoid}}(C_NULL)
-    status = ccall(
-        TensorNetworks._t4a(:t4a_qtransform_cumsum_materialize),
-        Cint,
-        (Ptr{Cvoid}, Csize_t, Ref{Ptr{Cvoid}}),
-        layout_handle,
-        Csize_t(target_var),
-        out,
-    )
-    TensorNetworks._check_backend_status(status, context)
-    return _materialized_linear_operator(out[])
-end
-
-function _materialize_fourier(
-    layout_handle::Ptr{Cvoid},
-    target_var::Integer,
-    forward::Bool,
-    maxbonddim::Integer,
-    tolerance::Real,
-    context::AbstractString,
-)
-    _require_nonnegative_integer("maxbonddim", maxbonddim)
-    _require_nonnegative_real("tolerance", tolerance)
-
-    out = Ref{Ptr{Cvoid}}(C_NULL)
-    status = ccall(
-        TensorNetworks._t4a(:t4a_qtransform_fourier_materialize),
-        Cint,
-        (Ptr{Cvoid}, Csize_t, Int32, Csize_t, Cdouble, Ref{Ptr{Cvoid}}),
-        layout_handle,
-        Csize_t(target_var),
-        Int32(forward),
-        Csize_t(maxbonddim),
-        Float64(tolerance),
-        out,
-    )
-    TensorNetworks._check_backend_status(status, context)
-    return _materialized_linear_operator(out[])
-end
-
-function _materialize_affine(
-    layout_handle::Ptr{Cvoid},
-    a_num,
-    a_den,
-    b_num,
-    b_den,
-    bc::Symbol,
-    context::AbstractString,
-)
-    _require_nonzero_integer("a_den", a_den)
-    _require_nonzero_integer("b_den", b_den)
-
-    a_num_c = Int64[Int64(a_num)]
-    a_den_c = Int64[Int64(a_den)]
-    b_num_c = Int64[Int64(b_num)]
-    b_den_c = Int64[Int64(b_den)]
-    bc_c = Cint[TensorNetworks._bc_code(bc)]
-    out = Ref{Ptr{Cvoid}}(C_NULL)
-    status = ccall(
-        TensorNetworks._t4a(:t4a_qtransform_affine_materialize),
-        Cint,
-        (
-            Ptr{Cvoid},
-            Ptr{Int64},
-            Ptr{Int64},
-            Ptr{Int64},
-            Ptr{Int64},
-            Csize_t,
-            Csize_t,
-            Ptr{Cint},
-            Ref{Ptr{Cvoid}},
-        ),
-        layout_handle,
-        a_num_c,
-        a_den_c,
-        b_num_c,
-        b_den_c,
-        Csize_t(1),
-        Csize_t(1),
-        bc_c,
-        out,
-    )
-    TensorNetworks._check_backend_status(status, context)
-    return _materialized_linear_operator(out[])
-end
-
 """
     shift_operator(r, offset; bc=:periodic)
 
@@ -226,7 +38,7 @@ function shift_operator(r::Integer, offset::Integer; bc=:periodic)
     try
         return _materialize_shift(layout_handle, 0, offset, bc, "materializing shift operator")
     finally
-        TensorNetworks._release_qtt_layout_handle(layout_handle)
+        _release_qtt_layout_handle(layout_handle)
     end
 end
 
@@ -253,7 +65,7 @@ function shift_operator_multivar(
             "materializing multivar shift operator",
         )
     finally
-        TensorNetworks._release_qtt_layout_handle(layout_handle)
+        _release_qtt_layout_handle(layout_handle)
     end
 end
 
@@ -267,7 +79,7 @@ function flip_operator(r::Integer; bc=:periodic)
     try
         return _materialize_flip(layout_handle, 0, bc, "materializing flip operator")
     finally
-        TensorNetworks._release_qtt_layout_handle(layout_handle)
+        _release_qtt_layout_handle(layout_handle)
     end
 end
 
@@ -287,7 +99,7 @@ function flip_operator_multivar(r::Integer, nvars::Integer, target::Integer; bc=
             "materializing multivar flip operator",
         )
     finally
-        TensorNetworks._release_qtt_layout_handle(layout_handle)
+        _release_qtt_layout_handle(layout_handle)
     end
 end
 
@@ -306,7 +118,7 @@ function phase_rotation_operator(r::Integer, theta)
             "materializing phase rotation operator",
         )
     finally
-        TensorNetworks._release_qtt_layout_handle(layout_handle)
+        _release_qtt_layout_handle(layout_handle)
     end
 end
 
@@ -326,7 +138,7 @@ function phase_rotation_operator_multivar(r::Integer, theta, nvars::Integer, tar
             "materializing multivar phase rotation operator",
         )
     finally
-        TensorNetworks._release_qtt_layout_handle(layout_handle)
+        _release_qtt_layout_handle(layout_handle)
     end
 end
 
@@ -340,7 +152,7 @@ function cumsum_operator(r::Integer)
     try
         return _materialize_cumsum(layout_handle, 0, "materializing cumsum operator")
     finally
-        TensorNetworks._release_qtt_layout_handle(layout_handle)
+        _release_qtt_layout_handle(layout_handle)
     end
 end
 
@@ -366,7 +178,7 @@ function fourier_operator(
             "materializing Fourier operator",
         )
     finally
-        TensorNetworks._release_qtt_layout_handle(layout_handle)
+        _release_qtt_layout_handle(layout_handle)
     end
 end
 
@@ -388,7 +200,7 @@ function affine_operator(r::Integer, a_num, a_den, b_num, b_den; bc=:periodic)
             "materializing affine operator",
         )
     finally
-        TensorNetworks._release_qtt_layout_handle(layout_handle)
+        _release_qtt_layout_handle(layout_handle)
     end
 end
 
@@ -409,5 +221,3 @@ Construct a metadata-only quantics binary-operator placeholder.
 # Deferred for the Phase 1 materialization pass.
 binaryop_operator(r::Integer, a1, b1, a2, b2; bc1=:periodic, bc2=:periodic) =
     _placeholder_operator(:binaryop; r, a1, b1, a2, b2, bc1, bc2)
-
-end

--- a/src/Tensor4all.jl
+++ b/src/Tensor4all.jl
@@ -28,7 +28,7 @@ include("QuanticsGrids.jl")
 include("QuanticsTCI.jl")
 include("QuanticsTransform.jl")
 
-using .TensorNetworks: add, dot, inner, dist, linkdims, linkinds, siteinds
+using .TensorNetworks: add, dot, inner, dist, linkdims, linkinds, siteinds, orthogonalize, truncate
 
 export SKELETON_PHASE
 export SkeletonPhaseError, SkeletonNotImplemented, BackendUnavailableError
@@ -41,6 +41,7 @@ export dag
 export dot, inner, dist
 export linkinds, linkdims, siteinds
 export norm
+export orthogonalize, truncate
 export Tensor, inds, rank, dims, swapinds, contract
 export svd, qr
 export TensorNetworks, SimpleTT, TensorCI, QuanticsGrids, QuanticsTCI, QuanticsTransform

--- a/src/Tensor4all.jl
+++ b/src/Tensor4all.jl
@@ -26,7 +26,7 @@ include("TensorNetworks.jl")
 include("TensorCI.jl")
 include("QuanticsGrids.jl")
 include("QuanticsTCI.jl")
-include("QuanticsTransform.jl")
+include("QuanticsTransform/QuanticsTransform.jl")
 
 using .TensorNetworks: add, dot, inner, dist, linkdims, linkinds, siteinds, orthogonalize, truncate
 

--- a/src/Tensor4all.jl
+++ b/src/Tensor4all.jl
@@ -37,9 +37,11 @@ export Index, dim, id, tags, plev, hastag
 export sim, prime, noprime, setprime
 export replaceind, replaceinds, commoninds, uniqueinds
 export add
+export dag
 export dot, inner, dist
 export norm
 export Tensor, inds, rank, dims, swapinds, contract
+export svd, qr
 export TensorNetworks, SimpleTT, TensorCI, QuanticsGrids, QuanticsTCI, QuanticsTransform
 
 end

--- a/src/Tensor4all.jl
+++ b/src/Tensor4all.jl
@@ -28,7 +28,7 @@ include("QuanticsGrids.jl")
 include("QuanticsTCI.jl")
 include("QuanticsTransform.jl")
 
-using .TensorNetworks: add, dot, inner, dist
+using .TensorNetworks: add, dot, inner, dist, linkdims, linkinds, siteinds
 
 export SKELETON_PHASE
 export SkeletonPhaseError, SkeletonNotImplemented, BackendUnavailableError
@@ -39,6 +39,7 @@ export replaceind, replaceinds, commoninds, uniqueinds
 export add
 export dag
 export dot, inner, dist
+export linkinds, linkdims, siteinds
 export norm
 export Tensor, inds, rank, dims, swapinds, contract
 export svd, qr

--- a/src/TensorNetworks.jl
+++ b/src/TensorNetworks.jl
@@ -3,12 +3,14 @@ module TensorNetworks
 using Libdl
 import LinearAlgebra
 import LinearAlgebra: norm
-using ..Tensor4all: BackendUnavailableError, Index, Tensor, SkeletonNotImplemented, dim, hastag, id, inds, plev, prime, rank, require_backend, tags
+import ..Tensor4all: dag
+using ..Tensor4all: BackendUnavailableError, Index, Tensor, SkeletonNotImplemented, commoninds, dim, hastag, id, inds, plev, prime, rank, require_backend, tags
 
 const _LINK_TAG = "Link"
 
 export TensorTrain, LinearOperator
-export add, dot, inner, dist
+export add, dag, dot, inner, dist
+export linkinds, linkdims, siteinds
 export norm
 export set_input_space!, set_output_space!, set_iospaces!, apply
 export findsite, findsites, findallsiteinds_by_tag, findallsites_by_tag
@@ -24,6 +26,7 @@ include("TensorNetworks/transforms.jl")
 include("TensorNetworks/backend/capi.jl")
 include("TensorNetworks/backend/tensors.jl")
 include("TensorNetworks/backend/treetn.jl")
+include("TensorNetworks/backend/treetn_queries.jl")
 include("TensorNetworks/backend/apply.jl")
 include("TensorNetworks/deferred.jl")
 

--- a/src/TensorNetworks.jl
+++ b/src/TensorNetworks.jl
@@ -12,6 +12,7 @@ export TensorTrain, LinearOperator
 export add, dag, dot, inner, dist
 export linkinds, linkdims, siteinds
 export norm
+export orthogonalize, truncate
 export set_input_space!, set_output_space!, set_iospaces!, apply
 export findsite, findsites, findallsiteinds_by_tag, findallsites_by_tag
 export replace_siteinds!, replace_siteinds, replace_siteinds_part!

--- a/src/TensorNetworks/backend/capi.jl
+++ b/src/TensorNetworks/backend/capi.jl
@@ -6,7 +6,52 @@ const _T4A_CONTRACT_METHOD_ZIPUP = Cint(0)
 const _T4A_CONTRACT_METHOD_FIT = Cint(1)
 const _T4A_CONTRACT_METHOD_NAIVE = Cint(2)
 
+const _T4A_QTT_LAYOUT_INTERLEAVED = Cint(1)
+const _T4A_QTT_LAYOUT_FUSED = Cint(2)
+
+const _T4A_BC_PERIODIC = Cint(0)
+const _T4A_BC_OPEN = Cint(1)
+
 _t4a(symbol::Symbol) = Libdl.dlsym(require_backend(), symbol)
+
+function _bc_code(bc::Symbol)
+    bc === :periodic && return _T4A_BC_PERIODIC
+    bc === :open && return _T4A_BC_OPEN
+    throw(ArgumentError("unknown boundary condition $bc. Expected :periodic or :open"))
+end
+
+function _new_qtt_layout_handle(nvars::Integer, resolutions::Vector{<:Integer})
+    nvars > 0 || throw(ArgumentError("nvars must be positive, got $nvars"))
+    length(resolutions) == nvars || throw(
+        DimensionMismatch("expected $nvars variable resolutions, got $(length(resolutions))"),
+    )
+    all(>(0), resolutions) || throw(
+        ArgumentError("variable resolutions must all be positive, got $resolutions"),
+    )
+    length(unique(resolutions)) == 1 || throw(
+        ArgumentError("fused QTT layouts require all variable resolutions to match, got $resolutions"),
+    )
+
+    out = Ref{Ptr{Cvoid}}(C_NULL)
+    res_c = Csize_t[Csize_t(r) for r in resolutions]
+    status = ccall(
+        _t4a(:t4a_qtt_layout_new),
+        Cint,
+        (Cint, Csize_t, Ptr{Csize_t}, Ref{Ptr{Cvoid}}),
+        _T4A_QTT_LAYOUT_FUSED,
+        Csize_t(nvars),
+        res_c,
+        out,
+    )
+    _check_backend_status(status, "creating QTT layout")
+    return out[]
+end
+
+function _release_qtt_layout_handle(ptr::Ptr{Cvoid})
+    ptr == C_NULL && return nothing
+    ccall(_t4a(:t4a_qtt_layout_release), Cvoid, (Ptr{Cvoid},), ptr)
+    return nothing
+end
 
 function _c_string_from_buffer(buf::Vector{UInt8})
     nul = findfirst(==(0x00), buf)

--- a/src/TensorNetworks/backend/treetn.jl
+++ b/src/TensorNetworks/backend/treetn.jl
@@ -88,6 +88,15 @@ function _derive_llim_rlim(canonical_region::Vector{Int}, ntensors::Int)
     return 0, ntensors + 1
 end
 
+const _T4A_CANONICAL_FORM_UNITARY = Cint(0)
+const _T4A_CANONICAL_FORM_LU = Cint(1)
+
+function _canonical_form_code(form::Symbol)
+    form === :unitary && return _T4A_CANONICAL_FORM_UNITARY
+    form === :lu && return _T4A_CANONICAL_FORM_LU
+    throw(ArgumentError("unknown canonical form $form. Expected :unitary or :lu"))
+end
+
 function _treetn_scale(tt::TensorTrain, re::Float64, im::Float64)
     isempty(tt.data) && throw(ArgumentError("TensorTrain must not be empty for scalar multiply"))
 
@@ -149,6 +158,67 @@ function _treetn_from_handle(ptr::Ptr{Cvoid})
     canonical_region = _treetn_canonical_region(ptr)
     llim, rlim = _derive_llim_rlim(canonical_region, ntensors)
     return TensorTrain(tensors, llim, rlim)
+end
+
+"""
+    orthogonalize(tt, site; form=:unitary)
+
+Orthogonalize `tt` to the requested one-based `site` using the backend chain
+canonicalization routine.
+"""
+function orthogonalize(tt::TensorTrain, site::Integer; form::Symbol=:unitary)
+    isempty(tt.data) && throw(ArgumentError("TensorTrain must not be empty"))
+    1 <= site <= length(tt) || throw(ArgumentError("site must be in 1:$(length(tt)), got $site"))
+
+    scalar_kind = _promoted_scalar_kind(tt)
+    tt_handle = _new_treetn_handle(tt, scalar_kind)
+    try
+        status = ccall(
+            _t4a(:t4a_treetn_orthogonalize),
+            Cint,
+            (Ptr{Cvoid}, Csize_t, Cint),
+            tt_handle,
+            Csize_t(site - 1),
+            _canonical_form_code(form),
+        )
+        _check_backend_status(status, "orthogonalizing TensorTrain to site $site")
+        return _treetn_from_handle(tt_handle)
+    finally
+        _release_treetn_handle(tt_handle)
+    end
+end
+
+"""
+    truncate(tt; rtol=0.0, cutoff=0.0, maxdim=0)
+
+Truncate TensorTrain bond dimensions with backend truncation controls.
+"""
+function truncate(tt::TensorTrain; rtol::Real=0.0, cutoff::Real=0.0, maxdim::Integer=0)
+    isempty(tt.data) && throw(ArgumentError("TensorTrain must not be empty"))
+    rtol >= 0 || throw(ArgumentError("rtol must be nonnegative, got $rtol"))
+    cutoff >= 0 || throw(ArgumentError("cutoff must be nonnegative, got $cutoff"))
+    maxdim >= 0 || throw(ArgumentError("maxdim must be nonnegative, got $maxdim"))
+    (rtol == 0.0 && cutoff == 0.0 && maxdim == 0) && throw(
+        ArgumentError("At least one of rtol, cutoff, or maxdim must be specified"),
+    )
+
+    scalar_kind = _promoted_scalar_kind(tt)
+    tt_handle = _new_treetn_handle(tt, scalar_kind)
+    try
+        status = ccall(
+            _t4a(:t4a_treetn_truncate),
+            Cint,
+            (Ptr{Cvoid}, Cdouble, Cdouble, Csize_t),
+            tt_handle,
+            float(rtol),
+            float(cutoff),
+            Csize_t(maxdim),
+        )
+        _check_backend_status(status, "truncating TensorTrain")
+        return _treetn_from_handle(tt_handle)
+    finally
+        _release_treetn_handle(tt_handle)
+    end
 end
 
 """

--- a/src/TensorNetworks/backend/treetn_queries.jl
+++ b/src/TensorNetworks/backend/treetn_queries.jl
@@ -1,0 +1,91 @@
+"""
+    dag(tt)
+
+Return a TensorTrain with each site tensor complex-conjugated.
+"""
+function dag(tt::TensorTrain)
+    return TensorTrain([dag(t) for t in tt.data], tt.llim, tt.rlim)
+end
+
+"""
+    linkinds(tt)
+    linkinds(tt, i)
+
+Return the shared bond indices between adjacent tensors in `tt`.
+"""
+function linkinds(tt::TensorTrain)
+    isempty(tt.data) && return Index[]
+
+    links = Index[]
+    for i in 1:(length(tt) - 1)
+        push!(links, linkinds(tt, i))
+    end
+    return links
+end
+
+function linkinds(tt::TensorTrain, i::Integer)
+    1 <= i < length(tt) || throw(BoundsError(tt.data, i))
+
+    shared = commoninds(inds(tt[i]), inds(tt[i + 1]))
+    length(shared) == 1 || throw(
+        ArgumentError("Expected exactly 1 shared index between sites $i and $(i + 1), got $(length(shared))"),
+    )
+    return only(shared)
+end
+
+"""
+    linkdims(tt)
+
+Return the dimensions of the shared bond indices in `tt`.
+"""
+linkdims(tt::TensorTrain) = [dim(index) for index in linkinds(tt)]
+
+"""
+    siteinds(tt)
+    siteinds(tt, i)
+
+Return the non-bond indices attached to each tensor in `tt`.
+"""
+function siteinds(tt::TensorTrain)
+    isempty(tt.data) && return Vector{Index}[]
+
+    bond_set = Set{Index}()
+    for i in 1:(length(tt) - 1)
+        for index in commoninds(inds(tt[i]), inds(tt[i + 1]))
+            push!(bond_set, index)
+        end
+    end
+
+    return [filter(index -> !(index in bond_set), inds(tt[i])) for i in 1:length(tt)]
+end
+
+function siteinds(tt::TensorTrain, i::Integer)
+    1 <= i <= length(tt) || throw(BoundsError(tt.data, i))
+
+    bond_inds = Set{Index}()
+    if i > 1
+        for index in commoninds(inds(tt[i]), inds(tt[i - 1]))
+            push!(bond_inds, index)
+        end
+    end
+    if i < length(tt)
+        for index in commoninds(inds(tt[i]), inds(tt[i + 1]))
+            push!(bond_inds, index)
+        end
+    end
+
+    return filter(index -> !(index in bond_inds), inds(tt[i]))
+end
+
+function _extract_mpo_io_indices(tt::TensorTrain)
+    input_indices = Index[]
+    output_indices = Index[]
+    for site_inds in siteinds(tt)
+        length(site_inds) == 2 || throw(
+            ArgumentError("Expected 2 site indices per MPO tensor, got $(length(site_inds))"),
+        )
+        push!(output_indices, site_inds[1])
+        push!(input_indices, site_inds[2])
+    end
+    return input_indices, output_indices
+end

--- a/test/core/tensor_factorize.jl
+++ b/test/core/tensor_factorize.jl
@@ -1,0 +1,82 @@
+using Test
+using Tensor4all
+
+@testset "Tensor dag" begin
+    i = Index(2; tags=["i"])
+    j = Index(3; tags=["j"])
+    data = reshape(
+        ComplexF64[1 + 2im, 3 + 4im, 5 + 6im, 7 + 8im, 9 + 10im, 11 + 12im],
+        2,
+        3,
+    )
+    t = Tensor(data, [i, j])
+    d = dag(t)
+
+    @test inds(d) == [i, j]
+    @test d.data ≈ conj(data)
+
+    t_real = Tensor(reshape(collect(1.0:6.0), 2, 3), [i, j])
+    @test dag(t_real).data ≈ t_real.data
+end
+
+@testset "Tensor Array with index reordering" begin
+    i = Index(2; tags=["i"])
+    j = Index(3; tags=["j"])
+    data = reshape(collect(1.0:6.0), 2, 3)
+    t = Tensor(data, [i, j])
+
+    @test Array(t, i, j) ≈ data
+    @test Array(t, j, i) ≈ permutedims(data, (2, 1))
+    @test size(Array(t, j, i)) == (3, 2)
+end
+
+@testset "Tensor SVD" begin
+    i = Index(3; tags=["i"])
+    j = Index(4; tags=["j"])
+    data = reshape(collect(1.0:12.0), 3, 4)
+    t = Tensor(data, [i, j])
+
+    U, S, V = svd(t, [i])
+    reconstructed = contract(contract(U, S), dag(V))
+    @test isapprox(t, reconstructed; atol=1e-12)
+
+    U2, S2, V2 = svd(t, i)
+    @test isapprox(contract(contract(U2, S2), dag(V2)), t; atol=1e-12)
+
+    v1 = collect(1.0:3.0)
+    v2 = collect(1.0:4.0)
+    data_r1 = v1 * v2' + 1e-10 * randn(3, 4)
+    t_r1 = Tensor(data_r1, [i, j])
+    _, S3, _ = svd(t_r1, [i]; maxdim=1)
+    @test dims(S3) == (1, 1)
+
+    k = Index(2; tags=["k"])
+    t3 = Tensor(reshape(collect(1.0:24.0), 3, 4, 2), [i, j, k])
+    U4, S4, V4 = svd(t3, [i, j])
+    @test isapprox(t3, contract(contract(U4, S4), dag(V4)); atol=1e-10)
+
+    @test_throws ArgumentError svd(t, Index[])
+    @test_throws ArgumentError svd(t, [Index(5; tags=["x"])])
+    @test_throws ArgumentError svd(t, [i, j])
+end
+
+@testset "Tensor QR" begin
+    i = Index(3; tags=["i"])
+    j = Index(4; tags=["j"])
+    t = Tensor(reshape(collect(1.0:12.0), 3, 4), [i, j])
+
+    Q, R = qr(t, [i])
+    @test isapprox(t, contract(Q, R); atol=1e-12)
+
+    Q2, R2 = qr(t, i)
+    @test isapprox(t, contract(Q2, R2); atol=1e-12)
+
+    k = Index(2; tags=["k"])
+    t3 = Tensor(reshape(collect(1.0:24.0), 3, 4, 2), [i, j, k])
+    Q3, R3 = qr(t3, [i, j])
+    @test isapprox(t3, contract(Q3, R3); atol=1e-10)
+
+    @test_throws ArgumentError qr(t, Index[])
+    @test_throws ArgumentError qr(t, [Index(5; tags=["x"])])
+    @test_throws ArgumentError qr(t, [i, j])
+end

--- a/test/quanticstransform/materialize.jl
+++ b/test/quanticstransform/materialize.jl
@@ -1,0 +1,116 @@
+using Test
+using Tensor4all
+
+const TN = Tensor4all.TensorNetworks
+const QT = Tensor4all.QuanticsTransform
+
+@testset "QuanticsTransform materialization" begin
+    @testset "shift_operator" begin
+        @testset "periodic" begin
+            op = QT.shift_operator(3, 1; bc=:periodic)
+            @test op.mpo !== nothing
+            @test length(op.mpo) == 3
+            @test length(op.input_indices) == 3
+            @test length(op.output_indices) == 3
+        end
+
+        @testset "negative offset" begin
+            op = QT.shift_operator(3, -1; bc=:periodic)
+            @test op.mpo !== nothing
+        end
+
+        @testset "open BC" begin
+            op = QT.shift_operator(3, 1; bc=:open)
+            @test op.mpo !== nothing
+        end
+    end
+
+    @testset "flip_operator" begin
+        @testset "periodic" begin
+            op = QT.flip_operator(3; bc=:periodic)
+            @test op.mpo !== nothing
+            @test length(op.mpo) == 3
+        end
+
+        @testset "open" begin
+            op = QT.flip_operator(3; bc=:open)
+            @test op.mpo !== nothing
+        end
+    end
+
+    @testset "cumsum_operator" begin
+        op = QT.cumsum_operator(3)
+        @test op.mpo !== nothing
+        @test length(op.mpo) == 3
+    end
+
+    @testset "phase_rotation_operator" begin
+        for theta in [0.0, pi / 4, pi / 2, pi]
+            op = QT.phase_rotation_operator(3, theta)
+            @test op.mpo !== nothing
+        end
+    end
+
+    @testset "fourier_operator" begin
+        @testset "forward" begin
+            op = QT.fourier_operator(3; forward=true)
+            @test op.mpo !== nothing
+        end
+
+        @testset "inverse" begin
+            op = QT.fourier_operator(3; forward=false)
+            @test op.mpo !== nothing
+        end
+
+        @testset "with maxbonddim" begin
+            op = QT.fourier_operator(3; forward=true, maxbonddim=4)
+            @test op.mpo !== nothing
+        end
+    end
+
+    @testset "affine_operator" begin
+        op = QT.affine_operator(3, 1, 1, 1, 1; bc=:periodic)
+        @test op.mpo !== nothing
+        @test length(op.mpo) == 3
+    end
+
+    @testset "multivar operators" begin
+        @testset "shift_operator_multivar" begin
+            op = QT.shift_operator_multivar(2, 1, 2, 1; bc=:periodic)
+            @test op.mpo !== nothing
+            @test length(op.mpo) > 0
+        end
+
+        @testset "flip_operator_multivar" begin
+            op = QT.flip_operator_multivar(2, 2, 2; bc=:periodic)
+            @test op.mpo !== nothing
+        end
+
+        @testset "phase_rotation_operator_multivar" begin
+            op = QT.phase_rotation_operator_multivar(2, pi / 4, 2, 1)
+            @test op.mpo !== nothing
+        end
+    end
+
+    @testset "operator binding and apply" begin
+        op = QT.shift_operator(2, 1; bc=:periodic)
+        TN.set_iospaces!(op, op.input_indices, op.output_indices)
+
+        s_in = op.input_indices
+        link = Index(1; tags=["Link", "state-l=1"])
+        t1 = Tensor(reshape([1.0, 0.0], 2, 1), [s_in[1], link])
+        t2 = Tensor(reshape([1.0, 0.0], 1, 2), [link, s_in[2]])
+        state = TN.TensorTrain([t1, t2])
+
+        result = TN.apply(op, state)
+        @test TN.norm(result) > 0
+    end
+
+    @testset "deferred operators remain placeholder" begin
+        op = QT.binaryop_operator(3, 1, 0, 1, 0)
+        @test op.mpo === nothing
+
+        op2 = QT.affine_pullback_operator(3, (;))
+        @test op2.mpo === nothing
+    end
+end

--- a/test/quanticstransform/materialize.jl
+++ b/test/quanticstransform/materialize.jl
@@ -92,7 +92,7 @@ const QT = Tensor4all.QuanticsTransform
         end
     end
 
-    @testset "operator binding and apply" begin
+    @testset "shift_operator maps 00 to 01 on output indices" begin
         op = QT.shift_operator(2, 1; bc=:periodic)
         TN.set_iospaces!(op, op.input_indices, op.output_indices)
 
@@ -101,9 +101,14 @@ const QT = Tensor4all.QuanticsTransform
         t1 = Tensor(reshape([1.0, 0.0], 2, 1), [s_in[1], link])
         t2 = Tensor(reshape([1.0, 0.0], 1, 2), [link, s_in[2]])
         state = TN.TensorTrain([t1, t2])
+        @test map(only, TN.siteinds(state)) == op.input_indices
 
         result = TN.apply(op, state)
-        @test TN.norm(result) > 0
+        @test map(only, TN.siteinds(result)) == op.output_indices
+        @test Array(contract(result[1], result[2]), op.output_indices...) ≈ ComplexF64[
+            0.0 1.0
+            0.0 0.0
+        ]
     end
 
     @testset "deferred operators remain placeholder" begin

--- a/test/quanticstransform/surface.jl
+++ b/test/quanticstransform/surface.jl
@@ -10,7 +10,8 @@ using Tensor4all
 
     op = Tensor4all.QuanticsTransform.shift_operator(4, 1)
     @test op isa Tensor4all.TensorNetworks.LinearOperator
-    @test op.metadata.kind == :shift
-    @test op.metadata.r == 4
-    @test op.metadata.offset == 1
+    @test op.mpo !== nothing
+    @test length(op.mpo) == 4
+    @test length(op.input_indices) == 4
+    @test length(op.output_indices) == 4
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,13 +3,16 @@ using Tensor4all
 
 include("api/skeleton_alignment.jl")
 include("core/tensor_arithmetic.jl")
+include("core/tensor_factorize.jl")
 include("core/tensor_contract.jl")
 include("tensornetworks/tensortrain.jl")
 include("tensornetworks/llim_rlim.jl")
 include("tensornetworks/index_queries.jl")
+include("tensornetworks/queries.jl")
 include("tensornetworks/matchsiteinds.jl")
 include("tensornetworks/apply.jl")
 include("tensornetworks/arithmetic.jl")
+include("tensornetworks/orthogonalize_truncate.jl")
 include("tensornetworks/transform_helpers.jl")
 include("tensornetworks/skeleton_surface.jl")
 include("simplett/surface.jl")
@@ -23,3 +26,4 @@ if get(ENV, "T4A_SKIP_HDF5_TESTS", "0") != "1" && Base.find_package("HDF5") !== 
     include("extensions/hdf5_roundtrip.jl")
 end
 include("quanticstransform/surface.jl")
+include("quanticstransform/materialize.jl")

--- a/test/tensornetworks/orthogonalize_truncate.jl
+++ b/test/tensornetworks/orthogonalize_truncate.jl
@@ -1,0 +1,46 @@
+using Test
+using Tensor4all
+
+const TN = Tensor4all.TensorNetworks
+
+function _tt_linkdims(tt::TN.TensorTrain)
+    dims = Int[]
+    for position in 1:(length(tt) - 1)
+        shared = commoninds(inds(tt[position]), inds(tt[position + 1]))
+        links = [index for index in shared if hastag(index, "Link")]
+        isempty(links) && continue
+        push!(dims, dim(only(links)))
+    end
+    return dims
+end
+
+@testset "TensorTrain orthogonalize and truncate" begin
+    s1 = Index(2; tags=["s1"])
+    s2 = Index(2; tags=["s2"])
+    s3 = Index(2; tags=["s3"])
+    l1 = Index(4; tags=["Link", "l1"])
+    l2 = Index(4; tags=["Link", "l2"])
+
+    t1 = Tensor(randn(2, 4), [s1, l1])
+    t2 = Tensor(randn(4, 2, 4), [l1, s2, l2])
+    t3 = Tensor(randn(4, 2), [l2, s3])
+    tt = TN.TensorTrain([t1, t2, t3])
+
+    tt2 = TN.orthogonalize(tt, 2)
+    @test tt2.llim == 1
+    @test tt2.rlim == 3
+    @test tt.llim == 0
+    @test tt.rlim == 4
+
+    n1 = TN.norm(tt)
+    n2 = TN.norm(TN.orthogonalize(tt, 1))
+    @test n1 ≈ n2 rtol=1e-10
+
+    tt_trunc = TN.truncate(tt; maxdim=2)
+    @test all(d -> d <= 2, _tt_linkdims(tt_trunc))
+
+    @test_throws ArgumentError TN.orthogonalize(TN.TensorTrain(Tensor[]), 1)
+    @test_throws ArgumentError TN.orthogonalize(tt, 0)
+    @test_throws ArgumentError TN.truncate(TN.TensorTrain(Tensor[]); maxdim=2)
+    @test_throws ArgumentError TN.truncate(tt)
+end

--- a/test/tensornetworks/queries.jl
+++ b/test/tensornetworks/queries.jl
@@ -1,0 +1,65 @@
+using Test
+using Tensor4all
+
+@testset "TensorTrain queries" begin
+    s1 = Index(2; tags=["s1"])
+    s2 = Index(2; tags=["s2"])
+    s3 = Index(2; tags=["s3"])
+    l1 = Index(3; tags=["l1"])
+    l2 = Index(3; tags=["l2"])
+
+    t1 = Tensor(randn(2, 3), [s1, l1])
+    t2 = Tensor(randn(3, 2, 3), [l1, s2, l2])
+    t3 = Tensor(randn(3, 2), [l2, s3])
+    tt = TensorNetworks.TensorTrain([t1, t2, t3])
+
+    @testset "linkinds(tt)" begin
+        links = TensorNetworks.linkinds(tt)
+        @test length(links) == 2
+        @test links[1] == l1
+        @test links[2] == l2
+    end
+
+    @testset "linkinds(tt, i)" begin
+        @test TensorNetworks.linkinds(tt, 1) == l1
+        @test TensorNetworks.linkinds(tt, 2) == l2
+        @test_throws BoundsError TensorNetworks.linkinds(tt, 0)
+        @test_throws BoundsError TensorNetworks.linkinds(tt, 3)
+    end
+
+    @testset "linkdims(tt)" begin
+        @test TensorNetworks.linkdims(tt) == [3, 3]
+    end
+
+    @testset "siteinds(tt)" begin
+        sites = TensorNetworks.siteinds(tt)
+        @test length(sites) == 3
+        @test s1 in sites[1]
+        @test s2 in sites[2]
+        @test s3 in sites[3]
+    end
+
+    @testset "siteinds(tt, i)" begin
+        @test s1 in TensorNetworks.siteinds(tt, 1)
+        @test s2 in TensorNetworks.siteinds(tt, 2)
+        @test s3 in TensorNetworks.siteinds(tt, 3)
+        @test_throws BoundsError TensorNetworks.siteinds(tt, 0)
+        @test_throws BoundsError TensorNetworks.siteinds(tt, 4)
+    end
+
+    @testset "1-site TT (no links)" begin
+        tt1 = TensorNetworks.TensorTrain([Tensor(randn(2), [s1])])
+        @test TensorNetworks.linkinds(tt1) == Index[]
+        @test length(TensorNetworks.siteinds(tt1)) == 1
+    end
+
+    @testset "dag" begin
+        data_c = ComplexF64[1 + 2im, 3 + 4im, 5 + 6im, 7 + 8im, 9 + 10im, 11 + 12im]
+        tc = Tensor(reshape(data_c, 2, 3), [s1, l1])
+        tt_c = TensorNetworks.TensorTrain([tc])
+        tt_d = TensorNetworks.dag(tt_c)
+        @test inds(tt_d[1]) == inds(tc)
+        @test tt_d[1].data ≈ conj(tc.data)
+        @test length(tt_d) == 1
+    end
+end


### PR DESCRIPTION
## Summary

Phase 1 of BubbleTeaCI migration APIs. Adds core tensor factorization, TensorTrain operations, and QuanticsTransform operator materialization.

### Tensor (Core)
- `dag(t)` — conjugate (pure Julia)
- `Array(t, inds...)` — permute data to requested index order
- `svd(t, left_inds; rtol, cutoff, maxdim)` — via `t4a_tensor_svd` C API
- `qr(t, left_inds)` — via `t4a_tensor_qr` C API

### TensorTrain (TensorNetworks)
- `dag(tt)` — conjugate all site tensors
- `linkinds(tt)` / `linkinds(tt, i)` — bond indices
- `linkdims(tt)` — bond dimensions
- `siteinds(tt)` / `siteinds(tt, i)` — site indices
- `orthogonalize(tt, site; form=:unitary)` — via C API (non-destructive)
- `truncate(tt; rtol, cutoff, maxdim)` — via C API (non-destructive)

### QuanticsTransform
- All operators now materialize real MPO-backed `LinearOperator`s via existing `t4a_qtransform_*` C API
- Supported: shift, flip, cumsum, phase_rotation, fourier, affine (+ multivar variants)
- Deferred: `binaryop_operator`, `affine_pullback_operator` (remain metadata-only)
- Operator space binding: callers use `set_iospaces!` (AGENTS.md convention)
- Module split into focused files (QuanticsTransform/, capi_helpers.jl, operators.jl)

## Dependencies

- tensor4all/tensor4all-rs#421 (t4a_tensor_svd + t4a_tensor_qr) — merged
- Pin updated to `5082aca`

## Test plan

- [ ] All CI jobs pass (Julia 1.10/1.11, ubuntu/macOS)
- [ ] Tensor SVD/QR: reconstruct, truncation, rank-3, error paths
- [ ] TT orthogonalize/truncate: llim/rlim sync, norm preservation, bond dim reduction
- [ ] TT queries: linkinds, linkdims, siteinds, dag, edge cases
- [ ] QuanticsTransform: all operators materialize, multivar, semantic I/O direction test, apply roundtrip

🤖 Generated with [Claude Code](https://claude.com/claude-code)