### PR TITLE
docs: add Truncation Contract page (closes part of #48)

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,6 +10,7 @@ makedocs(
         "Getting Started" => "getting_started.md",
         "Architecture Status" => "modules.md",
         "API Reference" => "api.md",
+        "Truncation Contract" => "truncation.md",
         "Design Documents" => "design_documents.md",
         "Deferred Rework Plan" => "deferred_rework_plan.md",
     ],

--- a/docs/src/truncation.md
+++ b/docs/src/truncation.md
@@ -1,0 +1,99 @@
+# Truncation Contract
+
+Several `Tensor4all.TensorNetworks` operations expose three keyword
+arguments that control SVD-based truncation of bond dimensions:
+
+| Keyword | Meaning |
+|---|---|
+| `rtol::Real`   | Relative tolerance applied to singular values. A singular value `σ_i` is dropped when `σ_i / σ_max < rtol`. Default `0.0` disables. |
+| `cutoff::Real` | Convenience knob expressed in **squared-singular-value space**. Internally converted to `rtol = sqrt(cutoff)` and applied as a relative tolerance. Default `0.0` disables. |
+| `maxdim::Integer` | Hard upper bound on the bond dimension after truncation. Default `0` means no rank cap. |
+
+`maxdim` is independent of `rtol` / `cutoff` and can be combined with either.
+
+## Precedence between `rtol` and `cutoff`
+
+Only one of `rtol` and `cutoff` is fed to the backend per call:
+
+1. If `cutoff > 0`, the backend uses `sqrt(cutoff)` as the relative
+   tolerance (and `rtol` is ignored even if it is also set).
+2. Otherwise, if `rtol > 0`, the backend uses that value verbatim.
+3. Otherwise, no rtol-based truncation is applied.
+
+This precedence is fixed by the C API resolver `select_tol` /
+`cutoff_to_rtol` in `tensor4all-rs/crates/tensor4all-capi/src/treetn.rs`
+(see [tensor4all/Tensor4all.jl#48](https://github.com/tensor4all/Tensor4all.jl/issues/48)
+for the discussion that pinned this contract).
+
+**Recommendation**: pick one of the two and stick to it within a given
+calculation. Setting both is silently equivalent to setting only
+`cutoff`.
+
+## Why `cutoff` is squared
+
+`cutoff` is expressed in the same space as the **sum of squared
+discarded singular values**, i.e. the squared Frobenius error norm of
+the truncation. Concretely, dropping a singular value `σ_i` contributes
+`σ_i²` to the truncation error norm. Setting `cutoff = ε²` is therefore
+roughly the same as bounding the discarded relative norm by `ε`.
+
+Internally the backend SVD truncation works in singular-value space, so
+the wrapper converts: `cutoff` (norm² space) → `sqrt(cutoff)`
+(singular-value space) → `rtol`.
+
+This matches the convention used by ITensors / ITensorMPS where
+`cutoff` is the discarded weight and the rank-revealing SVD selects
+singular values whose squared sum stays above
+`(1 - cutoff) * ||σ||²`.
+
+## Functions that accept the contract
+
+The same `(rtol, cutoff, maxdim)` keyword set appears on every
+truncating entry point in the public surface:
+
+- `TensorNetworks.truncate(tt; rtol, cutoff, maxdim, form)`
+- `TensorNetworks.add(a, b; rtol, cutoff, maxdim)`
+- `TensorNetworks.contract(a, b; rtol, cutoff, maxdim, ...)`
+- `TensorNetworks.apply(op, state; rtol, cutoff, maxdim, ...)`
+- `TensorNetworks.linsolve(op, rhs; rtol, cutoff, maxdim, ...)`
+- `TensorNetworks.split_to(...; rtol, cutoff, maxdim, final_sweep)`
+  (truncation only takes effect when `final_sweep = true`)
+- `TensorNetworks.restructure_to(...; split_rtol, split_cutoff,
+  split_maxdim, ...)` (forwards the same contract; phase-prefixed names
+  separate the split / swap / final passes)
+- `Tensor4all.svd(t, left_inds; rtol, cutoff, maxdim)`
+
+The argument validation is uniform across these calls: negative values
+raise `ArgumentError` early in Julia before reaching the C boundary.
+
+## Sentinel meanings
+
+| Value | Meaning |
+|---|---|
+| `rtol = 0.0` | Disable rtol-based truncation. |
+| `cutoff = 0.0` | Disable cutoff-based truncation. |
+| `maxdim = 0` | No upper bound on bond dimension. |
+
+The combination `(rtol = 0, cutoff = 0, maxdim = 0)` is rejected by
+`truncate` (with a clear `ArgumentError`) because it would request a
+truncation operation that does nothing. Other entry points (such as
+`add` or `contract`) accept the all-zero combination as "no
+truncation".
+
+## Future work
+
+The current contract is intentionally minimal: every truncating call
+takes the same three knobs and dispatches them through the same
+`select_tol` / `cutoff_to_rtol` resolver. Planned future enhancements:
+
+- A user-facing `TruncationScheme` type so callers can express richer
+  policies (e.g. "absolute cutoff in singular-value space",
+  "discard-weight-only", or "rtol with a separate per-bond override")
+  in a single value rather than a triple of keyword arguments.
+- Per-bond / per-edge truncation overrides for tree-shaped networks.
+- An explicit accessor that returns the singular values discarded by
+  the most recent truncation call, so that downstream packages can
+  audit numerical accuracy.
+
+These will land as additive changes; the existing keyword surface will
+remain supported.

--- a/src/TensorNetworks/backend/treetn.jl
+++ b/src/TensorNetworks/backend/treetn.jl
@@ -199,18 +199,25 @@ end
 """
     truncate(tt; rtol=0.0, cutoff=0.0, maxdim=0, form=:unitary)
 
-Truncate TensorTrain bond dimensions with backend truncation controls.
+Truncate TensorTrain bond dimensions.
 
 # Keyword arguments
 
-- `rtol`: relative tolerance for the SVD/LU truncation. `0.0` disables.
-- `cutoff`: absolute cutoff fed to the same backend resolver as `rtol`.
-- `maxdim`: maximum bond dimension. `0` (default) means no rank cap.
+- `rtol`: relative tolerance applied to singular values. `0.0` disables.
+- `cutoff`: convenience knob in squared-singular-value space. Internally
+  converted to `rtol = sqrt(cutoff)` and takes precedence over `rtol`
+  when both are nonzero. `0.0` disables.
+- `maxdim`: hard upper bound on the bond dimension after truncation.
+  `0` (default) means no rank cap.
 - `form`: factorization used to truncate. One of `:unitary` (SVD-based,
   default) or `:lu`.
 
 At least one of `rtol`, `cutoff`, or `maxdim` must be set; otherwise an
 `ArgumentError` is thrown.
+
+See also the [Truncation Contract](@ref) page for the precedence rules
+between `rtol` and `cutoff`, the `sqrt` conversion, and the meaning of
+the sentinel values across every truncating entry point.
 """
 function truncate(tt::TensorTrain; rtol::Real=0.0, cutoff::Real=0.0, maxdim::Integer=0, form::Symbol=:unitary)
     isempty(tt.data) && throw(ArgumentError("TensorTrain must not be empty"))


### PR DESCRIPTION
## Summary

Adds `docs/src/truncation.md` documenting the actual `rtol` / `cutoff` /
`maxdim` semantics used by every truncating entry point on the Julia
side. Closes the documentation half of issue #48 item 5.

The page pins the contract that the C API resolver
(`select_tol` + `cutoff_to_rtol` in
`tensor4all-rs/crates/tensor4all-capi/src/treetn.rs`) actually
implements:

1. `cutoff > 0` takes precedence over `rtol > 0` — the backend uses
   `sqrt(cutoff)` as the relative tolerance.
2. Otherwise `rtol` is used verbatim.
3. Otherwise no rtol-based truncation.

It also describes why `cutoff` lives in squared-singular-value space
(matches the discarded weight convention from ITensors / ITensorMPS),
enumerates every public entry point that consumes the contract, and
flags the planned `TruncationScheme` type as future work for
richer per-policy / per-bond specification.

`truncate`'s docstring is updated to reflect the actual conversion and
to link the new doc page; the rest of the truncating functions (which
already documented their args) can pick up the cross-reference
incrementally.

Closes part of #48 (item 5).

## Test plan

- [ ] CI builds documentation cleanly.
- [ ] `scripts/check_autodocs_coverage.jl` passes.
- [x] Verified locally: docs/make.jl renders truncation.md without
      errors (Docker build, with the prebuilt
      `libtensor4all_capi.so` mounted in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)