### PR TITLE
[codex] add replaceind compatibility APIs

### DIFF
--- a/docs/plans/2026-04-20-replaceind-design.md
+++ b/docs/plans/2026-04-20-replaceind-design.md
@@ -1,0 +1,122 @@
+# Tensor Replaceind Design
+
+## Summary
+
+Issue #60 reports that `Tensor4all.Tensor` is missing a `replaceind` method.
+Users currently need to reconstruct a tensor manually from copied dense data
+and rewritten index metadata. This is inconsistent with the existing
+`replaceind` / `replaceinds` helpers on index collections and with the
+`ITensors.jl` API the project wants to emulate.
+
+## Goals
+
+- Add `Tensor`-level index replacement APIs that follow the `ITensors.jl`
+  calling style closely enough for downstream code migration.
+- Keep the implementation Julia-owned and metadata-only. Replacing indices on a
+  `Tensor` must not require new Rust or C API support.
+- Preserve the current `Tensor` representation and constructor invariants.
+
+## Non-goals
+
+- No C API changes.
+- No dense data permutation or tensor contraction changes.
+- No attempt to preserve ITensors storage-view semantics. Tensor4all tensors are
+  value-like Julia objects whose constructors currently copy dense data.
+
+## Proposed public API
+
+Add the following exported methods:
+
+- `replaceind(t::Tensor, old::Index, new::Index)`
+- `replaceind(t::Tensor, replacement::Pair{Index,Index})`
+- `replaceinds(t::Tensor, oldinds, newinds)`
+- `replaceinds(t::Tensor, replacements::Pair...)`
+- `replaceind!(t::Tensor, old::Index, new::Index)`
+- `replaceind!(t::Tensor, replacement::Pair{Index,Index})`
+- `replaceinds!(t::Tensor, oldinds, newinds)`
+- `replaceinds!(t::Tensor, replacements::Pair...)`
+
+Also extend the existing index-collection helpers so the calling contract
+matches the tensor methods:
+
+- `replaceind(xs::AbstractVector{Index}, replacement::Pair{Index,Index})`
+- `replaceinds(xs::AbstractVector{Index})`
+- `replaceinds(xs::AbstractVector{Index}, ())`
+- `replaceinds(xs::AbstractVector{Index}, oldinds, newinds)`
+
+## Semantics
+
+The semantics should intentionally follow `ITensors.jl` where practical:
+
+- Missing indices are ignored. Replacing an index that does not occur is a
+  no-op.
+- The old and new index collections must have matching lengths.
+- Any replacement that targets a present index must preserve dimension:
+  `dim(old) == dim(new)`. Otherwise throw `ArgumentError`.
+- Pair-based multi-replacement is resolved against the original index set, not
+  by sequentially rewriting the output of prior replacements. This avoids
+  accidental cascading replacements and matches the ITensors intent.
+- Non-mutating tensor methods return a new `Tensor` that keeps the same dense
+  data values and the same `backend_handle`.
+- Mutating tensor methods rewrite only `t.inds` in place. They must not touch
+  `t.data`.
+
+## Architecture
+
+Implement the replacement contract once in `src/Core/Index.jl` as a shared
+helper that:
+
+1. normalizes the user-facing replacement forms,
+2. validates collection lengths,
+3. checks dimension compatibility for indices that are actually present, and
+4. returns the rewritten `Vector{Index}`.
+
+`src/Core/Tensor.jl` should delegate all index rewriting to those shared
+helpers and only handle tensor-specific object construction versus in-place
+metadata mutation.
+
+This keeps all replacement rules centralized in `Core`, avoids code drift
+between vector and tensor methods, and fits the project policy that Julia owns
+semantic validation.
+
+## Error handling
+
+Use early Julia validation with actionable messages:
+
+- Length mismatch between `oldinds` and `newinds`: `DimensionMismatch`
+- Attempted replacement with different dimensions for a present index:
+  `ArgumentError` including both indices and dimensions
+- Unsupported pair payloads such as `[] => []` for `Tensor`: allow on index
+  collections for ITensors-style convenience, but do not add loose `Any`
+  tensor signatures unless a concrete downstream need appears
+
+## Testing strategy
+
+Add focused unit tests that mirror the representative `ITensors.jl` cases:
+
+- `replaceind` on `Tensor` is non-mutating
+- `replaceind!` mutates only index metadata
+- `replaceinds` supports pair notation
+- empty replacement lists are no-ops for index collections
+- missing indices are ignored
+- dimension mismatch throws
+- multi-replacement uses original positions rather than sequential cascading
+
+## Documentation impact
+
+Document the new exported tensor methods with concise docstrings in
+`src/Core/Tensor.jl`. Since they live in an existing source file already
+covered by API docs, no `@autodocs` page-list expansion should be needed.
+
+## Recommended implementation scope
+
+Keep this change narrowly focused on `Core`:
+
+- modify `src/Core/Index.jl`
+- modify `src/Core/Tensor.jl`
+- update `src/Tensor4all.jl` exports
+- extend `test/core/index.jl`
+- extend `test/core/tensor.jl`
+
+This closes issue #60 while also aligning the foundational replacement surface
+for future ITensors-style API compatibility.

--- a/docs/plans/2026-04-20-replaceind-implementation.md
+++ b/docs/plans/2026-04-20-replaceind-implementation.md
@@ -1,0 +1,291 @@
+# Replaceind Compatibility Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add ITensors-style `replaceind` / `replaceinds` APIs for `Tensor4all.Tensor` and align the underlying `Index`-collection replacement semantics with the same contract.
+
+**Architecture:** Keep all replacement semantics Julia-owned in `Core`. Centralize replacement normalization and validation in `src/Core/Index.jl`, then have `src/Core/Tensor.jl` build non-mutating and mutating tensor APIs on top of that shared logic so the tensor methods only manage metadata updates and object construction.
+
+**Tech Stack:** Julia, `Test`, existing `Tensor4all.Index` and `Tensor4all.Tensor` core types
+
+---
+
+### Task 1: Lock the desired index-collection replacement contract with failing tests
+
+**Files:**
+- Modify: `test/core/index.jl`
+
+**Step 1: Write the failing test**
+
+Add a new `@testset` that covers:
+
+- `replaceind([i, j], i => ip)` returns `[ip, j]`
+- `replaceinds([i, j], i => ip, j => jp)` returns `[ip, jp]`
+- `replaceinds([i, j]) == [i, j]`
+- `replaceinds([i, j], ()) == [i, j]`
+- `replaceinds([i, j], [i], [ip]) == [ip, j]`
+- `replaceinds([i, j], [missing_index], [ip]) == [i, j]`
+- `replaceinds([i, j], [i], [bad_dim_index])` throws `ArgumentError`
+- `replaceinds([i, j], i => j, j => ip)` is resolved against the original
+  indices, so the result is `[j, ip]` rather than a sequentially cascaded
+  rewrite
+
+Use concrete indices such as:
+
+```julia
+i = Index(2; tags=["i"])
+j = Index(3; tags=["j"])
+ip = Index(2; tags=["ip"])
+jp = Index(3; tags=["jp"])
+bad = Index(5; tags=["bad"])
+missing_index = Index(2; tags=["missing"])
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `julia --startup-file=no --project=. test/core/index.jl`
+Expected: FAIL because pair notation, empty replacement no-ops, length-checked
+collection replacement, and non-sequential multi-replacement are not all
+implemented yet.
+
+**Step 3: Write minimal implementation**
+
+Do not change implementation yet. Use the failing test output to confirm the
+contract is locked.
+
+**Step 4: Run test to verify it still fails for the expected reason**
+
+Run: `julia --startup-file=no --project=. test/core/index.jl`
+Expected: FAIL with assertion mismatches or missing methods in the new
+replacement testset, not unrelated package-load errors.
+
+**Step 5: Commit**
+
+```bash
+git add test/core/index.jl
+git commit -m "test: lock index replacement compatibility contract"
+```
+
+### Task 2: Implement shared index replacement normalization and validation
+
+**Files:**
+- Modify: `src/Core/Index.jl`
+- Test: `test/core/index.jl`
+
+**Step 1: Write the failing test**
+
+Use the tests from Task 1.
+
+**Step 2: Run test to verify it fails**
+
+Run: `julia --startup-file=no --project=. test/core/index.jl`
+Expected: FAIL because `src/Core/Index.jl` still uses sequential pair
+replacement and lacks the new compatibility entry points.
+
+**Step 3: Write minimal implementation**
+
+Add a shared helper layer in `src/Core/Index.jl`:
+
+```julia
+function _replaceinds_impl(xs::AbstractVector{Index}, olds::AbstractVector{Index}, news::AbstractVector{Index})
+    length(olds) == length(news) || throw(DimensionMismatch(...))
+    ys = collect(xs)
+    for (pos, current) in pairs(xs)
+        match = findfirst(==(current), olds)
+        isnothing(match) && continue
+        replacement = news[match]
+        dim(current) == dim(replacement) || throw(ArgumentError(...))
+        ys[pos] = replacement
+    end
+    return ys
+end
+```
+
+Then expose these public methods:
+
+```julia
+replaceinds(xs::AbstractVector{Index}) = collect(xs)
+replaceinds(xs::AbstractVector{Index}, replacements::Tuple{}) = collect(xs)
+replaceind(xs::AbstractVector{Index}, old::Index, new::Index) = _replaceinds_impl(xs, (old,), (new,))
+replaceind(xs::AbstractVector{Index}, replacement::Pair{Index,Index}) = replaceind(xs, first(replacement), last(replacement))
+replaceinds(xs::AbstractVector{Index}, replacements::Pair{Index,Index}...) = _replaceinds_impl(xs, first.(replacements), last.(replacements))
+replaceinds(xs::AbstractVector{Index}, olds, news) = _replaceinds_impl(xs, collect(olds), collect(news))
+```
+
+Keep the dimension check conditional on the old index actually appearing in
+`xs`, so missing indices remain no-ops.
+
+**Step 4: Run test to verify it passes**
+
+Run: `julia --startup-file=no --project=. test/core/index.jl`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/Core/Index.jl test/core/index.jl
+git commit -m "feat: align core index replacement semantics with ITensors"
+```
+
+### Task 3: Lock tensor-level replacement APIs with failing tests
+
+**Files:**
+- Modify: `test/core/tensor.jl`
+
+**Step 1: Write the failing test**
+
+Add a new `@testset` covering:
+
+- `replaceind(tensor, i, ip)` returns a new tensor with `inds == [ip, j]`
+- `replaceind(tensor, i => ip)` also works
+- the original tensor remains `[i, j]`
+- `replaceinds(tensor, (i, j), (ip, jp))` returns `[ip, jp]`
+- `replaceinds(tensor, i => ip, j => jp)` returns `[ip, jp]`
+- `replaceind!(tensor, i, ip)` mutates the original tensor indices in place
+- `replaceinds!(tensor, (i, j), (ip, jp))` mutates in place
+- replacing a missing index is a no-op
+- replacing a present index with different `dim` throws `ArgumentError`
+- non-mutating methods preserve the dense data contents and `backend_handle`
+
+Construct one tensor with an explicit handle to verify preservation:
+
+```julia
+handle = Ptr{Cvoid}(0x1)
+tensor = Tensor(data, [i, j]; backend_handle=handle)
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `julia --startup-file=no --project=. test/core/tensor.jl`
+Expected: FAIL because tensor-level replacement methods do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Do not implement yet. Use the failing output to verify the tests are targeting
+missing tensor APIs rather than unrelated tensor behavior.
+
+**Step 4: Run test to verify it still fails for the expected reason**
+
+Run: `julia --startup-file=no --project=. test/core/tensor.jl`
+Expected: FAIL with missing method errors or failed assertions in the new
+replacement tests.
+
+**Step 5: Commit**
+
+```bash
+git add test/core/tensor.jl
+git commit -m "test: lock tensor replaceind compatibility"
+```
+
+### Task 4: Implement tensor-level replace APIs
+
+**Files:**
+- Modify: `src/Core/Tensor.jl`
+- Modify: `src/Tensor4all.jl`
+- Test: `test/core/tensor.jl`
+
+**Step 1: Write the failing test**
+
+Use the tests from Task 3.
+
+**Step 2: Run test to verify it fails**
+
+Run: `julia --startup-file=no --project=. test/core/tensor.jl`
+Expected: FAIL because `Tensor` has no `replaceind` or `replaceinds` methods.
+
+**Step 3: Write minimal implementation**
+
+Add concise docstrings and the following method family to `src/Core/Tensor.jl`:
+
+```julia
+function replaceind(t::Tensor, old::Index, new::Index)
+    return Tensor(copy(t.data), replaceind(inds(t), old, new); backend_handle=t.backend_handle)
+end
+
+replaceind(t::Tensor, replacement::Pair{Index,Index}) = replaceind(t, first(replacement), last(replacement))
+
+function replaceinds(t::Tensor, olds, news)
+    return Tensor(copy(t.data), replaceinds(inds(t), olds, news); backend_handle=t.backend_handle)
+end
+
+function replaceinds(t::Tensor, replacements::Pair{Index,Index}...)
+    return Tensor(copy(t.data), replaceinds(inds(t), replacements...); backend_handle=t.backend_handle)
+end
+
+function replaceind!(t::Tensor, old::Index, new::Index)
+    t.inds .= replaceind(t.inds, old, new)
+    return t
+end
+```
+
+Also add the matching `Pair` and multi-replacement mutating methods, and export
+`replaceind!` / `replaceinds!` from `src/Tensor4all.jl`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `julia --startup-file=no --project=. test/core/tensor.jl`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/Core/Tensor.jl src/Tensor4all.jl test/core/tensor.jl
+git commit -m "feat: add tensor replaceind compatibility apis"
+```
+
+### Task 5: Run focused regression coverage
+
+**Files:**
+- Test: `test/core/index.jl`
+- Test: `test/core/tensor.jl`
+
+**Step 1: Run the focused tests**
+
+Run: `julia --startup-file=no --project=. test/core/index.jl`
+Expected: PASS
+
+**Step 2: Run the tensor tests**
+
+Run: `julia --startup-file=no --project=. test/core/tensor.jl`
+Expected: PASS
+
+**Step 3: Run package-level smoke coverage**
+
+Run: `julia --startup-file=no --project=. test/runtests.jl`
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "test: verify replaceind compatibility coverage"
+```
+
+### Task 6: Verify docs and API load path
+
+**Files:**
+- Modify: `docs/src/api.md` only if autodocs coverage needs adjustment
+- Test: `docs/make.jl`
+
+**Step 1: Check whether docs wiring needs updates**
+
+Run: `rg -n "Core/Tensor.jl|Core/Index.jl" docs/src/api.md`
+Expected: Existing autodocs coverage already includes these files. If not,
+update the relevant `Pages = [...]` list.
+
+**Step 2: Build docs**
+
+Run: `julia --startup-file=no --project=docs docs/make.jl`
+Expected: PASS
+
+**Step 3: Run package load smoke test**
+
+Run: `julia --startup-file=no --project=. -e 'using Tensor4all; println("ok")'`
+Expected: PASS with output `ok`
+
+**Step 4: Commit**
+
+```bash
+git add docs/src/api.md
+git commit -m "docs: keep replaceind api coverage in sync"
+```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -10,6 +10,7 @@
 - `Tensor4all.hastag`, `Tensor4all.sim`, `Tensor4all.prime`,
   `Tensor4all.noprime`, `Tensor4all.setprime`
 - `Tensor4all.replaceind`, `Tensor4all.replaceinds`
+- `Tensor4all.replaceind!`, `Tensor4all.replaceinds!`
 - `Tensor4all.commoninds`, `Tensor4all.uniqueinds`
 - `Tensor4all.inds`, `Tensor4all.rank`, `Tensor4all.dims`,
   `Tensor4all.swapinds`

--- a/src/Core/Index.jl
+++ b/src/Core/Index.jl
@@ -137,17 +137,72 @@ end
 
 Replace `old` by `new` in the index collection `xs`.
 """
-replaceind(xs::AbstractVector{Index}, old::Index, new::Index) = [x == old ? new : x for x in xs]
+function replaceind(xs::AbstractVector{Index}, old::Index, new::Index)
+    return _replaceinds_impl(xs, (old,), (new,))
+end
+
+replaceind(xs::AbstractVector{Index}, replacement::Pair{Index,Index}) = replaceind(
+    xs,
+    first(replacement),
+    last(replacement),
+)
 
 """
     replaceinds(xs, replacements...)
 
-Apply multiple index replacements in sequence to `xs`.
+Apply multiple index replacements to `xs`, resolving matches against the
+original index collection.
 """
+replaceinds(xs::AbstractVector{Index}) = collect(xs)
+replaceinds(xs::AbstractVector{Index}, replacements::Tuple{}) = collect(xs)
+
 function replaceinds(xs::AbstractVector{Index}, replacements::Pair{Index,Index}...)
+    return _replaceinds_impl(xs, first.(replacements), last.(replacements))
+end
+
+function replaceinds(
+    xs::AbstractVector{Index},
+    oldinds::AbstractVector{Index},
+    newinds::AbstractVector{Index},
+)
+    return _replaceinds_impl(xs, oldinds, newinds)
+end
+
+function replaceinds(
+    xs::AbstractVector{Index},
+    oldinds::Tuple{Vararg{Index}},
+    newinds::Tuple{Vararg{Index}},
+)
+    return _replaceinds_impl(xs, oldinds, newinds)
+end
+
+function _replaceinds_impl(
+    xs::AbstractVector{Index},
+    oldinds::Tuple{Vararg{Index}},
+    newinds::Tuple{Vararg{Index}},
+)
+    return _replaceinds_impl(xs, collect(oldinds), collect(newinds))
+end
+
+function _replaceinds_impl(
+    xs::AbstractVector{Index},
+    oldinds::AbstractVector{Index},
+    newinds::AbstractVector{Index},
+)
+    length(oldinds) == length(newinds) || throw(DimensionMismatch(
+        "replaceinds requires matching replacement lengths, got $(length(oldinds)) old indices and $(length(newinds)) new indices",
+    ))
+
     ys = collect(xs)
-    for (old, new) in replacements
-        ys = replaceind(ys, old, new)
+    for (position, current) in pairs(xs)
+        match = findfirst(==(current), oldinds)
+        isnothing(match) && continue
+
+        replacement = newinds[match]
+        dim(current) == dim(replacement) || throw(ArgumentError(
+            "Cannot replace index $current (dim=$(dim(current))) with $replacement (dim=$(dim(replacement))); dimensions must match",
+        ))
+        ys[position] = replacement
     end
     return ys
 end

--- a/src/Core/Tensor.jl
+++ b/src/Core/Tensor.jl
@@ -100,6 +100,90 @@ function swapinds(t::Tensor, a::Index, b::Index)
 end
 
 """
+    replaceind(t, old, new)
+
+Return a copy of `t` with index metadata `old` replaced by `new`.
+"""
+function replaceind(t::Tensor, old::Index, new::Index)
+    return Tensor(t.data, replaceind(inds(t), old, new); backend_handle=t.backend_handle)
+end
+
+replaceind(t::Tensor, replacement::Pair{Index,Index}) = replaceind(
+    t,
+    first(replacement),
+    last(replacement),
+)
+
+"""
+    replaceinds(t, replacements...)
+
+Return a copy of `t` with multiple index metadata replacements applied.
+"""
+function replaceinds(t::Tensor, replacements::Pair{Index,Index}...)
+    return Tensor(t.data, replaceinds(inds(t), replacements...); backend_handle=t.backend_handle)
+end
+
+function replaceinds(
+    t::Tensor,
+    oldinds::AbstractVector{Index},
+    newinds::AbstractVector{Index},
+)
+    return Tensor(t.data, replaceinds(inds(t), oldinds, newinds); backend_handle=t.backend_handle)
+end
+
+function replaceinds(
+    t::Tensor,
+    oldinds::Tuple{Vararg{Index}},
+    newinds::Tuple{Vararg{Index}},
+)
+    return Tensor(t.data, replaceinds(inds(t), oldinds, newinds); backend_handle=t.backend_handle)
+end
+
+"""
+    replaceind!(t, old, new)
+
+Replace index metadata `old` by `new` in `t`.
+"""
+function replaceind!(t::Tensor, old::Index, new::Index)
+    t.inds .= replaceind(t.inds, old, new)
+    return t
+end
+
+replaceind!(t::Tensor, replacement::Pair{Index,Index}) = replaceind!(
+    t,
+    first(replacement),
+    last(replacement),
+)
+
+"""
+    replaceinds!(t, replacements...)
+
+Apply multiple index metadata replacements in place to `t`.
+"""
+function replaceinds!(t::Tensor, replacements::Pair{Index,Index}...)
+    t.inds .= replaceinds(t.inds, replacements...)
+    return t
+end
+
+function replaceinds!(
+    t::Tensor,
+    oldinds::AbstractVector{Index},
+    newinds::AbstractVector{Index},
+)
+    t.inds .= replaceinds(t.inds, oldinds, newinds)
+    return t
+end
+
+function replaceinds!(
+    t::Tensor,
+    oldinds::Tuple{Vararg{Index}},
+    newinds::Tuple{Vararg{Index}},
+)
+    t.inds .= replaceinds(t.inds, oldinds, newinds)
+    return t
+end
+
+"""
     _match_index_permutation(source_inds, target_inds)
 
 Return the permutation that reorders `source_inds` to match `target_inds`.

--- a/src/Tensor4all.jl
+++ b/src/Tensor4all.jl
@@ -35,7 +35,7 @@ export SkeletonPhaseError, SkeletonNotImplemented, BackendUnavailableError
 export backend_library_path, require_backend
 export Index, dim, id, tags, plev, hastag
 export sim, prime, noprime, setprime
-export replaceind, replaceinds, commoninds, uniqueinds
+export replaceind, replaceinds, replaceind!, replaceinds!, commoninds, uniqueinds
 export add
 export dag
 export dot, inner, dist

--- a/test/core/index.jl
+++ b/test/core/index.jl
@@ -23,3 +23,27 @@ using Tensor4all
     @test Tensor4all.commoninds(xs, ys) == [j, ip]
     @test Tensor4all.uniqueinds(xs, ys) == [i]
 end
+
+@testset "Index replacement compatibility" begin
+    i = Tensor4all.Index(2; tags=["i"])
+    j = Tensor4all.Index(3; tags=["j"])
+    ip = Tensor4all.Index(2; tags=["ip"])
+    jp = Tensor4all.Index(3; tags=["jp"])
+    bad = Tensor4all.Index(5; tags=["bad"])
+    missing = Tensor4all.Index(2; tags=["missing"])
+
+    xs = [i, j]
+    @test Tensor4all.replaceind(xs, i, ip) == [ip, j]
+    @test Tensor4all.replaceind(xs, i => ip) == [ip, j]
+    @test Tensor4all.replaceinds(xs, i => ip, j => jp) == [ip, jp]
+    @test Tensor4all.replaceinds(xs) == xs
+    @test Tensor4all.replaceinds(xs, ()) == xs
+    @test Tensor4all.replaceinds(xs, [i], [ip]) == [ip, j]
+    @test Tensor4all.replaceinds(xs, [missing], [ip]) == xs
+    @test_throws ArgumentError Tensor4all.replaceinds(xs, [i], [bad])
+
+    a = Tensor4all.Index(2; tags=["a"])
+    b = Tensor4all.Index(2; tags=["b"])
+    ap = Tensor4all.Index(2; tags=["ap"])
+    @test Tensor4all.replaceinds([a, b], a => b, b => ap) == [b, ap]
+end

--- a/test/core/tensor.jl
+++ b/test/core/tensor.jl
@@ -16,5 +16,47 @@ using Tensor4all
     k = Tensor4all.Index(2; tags=["k"])
     @test_throws ArgumentError Tensor4all.Tensor(bad, [i, j, k])
     @test_throws DimensionMismatch Tensor4all.Tensor(data, [i])
-    @test_throws Tensor4all.SkeletonNotImplemented Tensor4all.contract(tensor, tensor)
+    contracted = Tensor4all.contract(tensor, tensor)
+    @test Tensor4all.rank(contracted) == 0
+    @test Tensor4all.dims(contracted) == ()
+    @test contracted.data[] == 91.0
+end
+
+@testset "Tensor replaceind compatibility" begin
+    i = Tensor4all.Index(2; tags=["i"])
+    j = Tensor4all.Index(3; tags=["j"])
+    ip = Tensor4all.Index(2; tags=["ip"])
+    jp = Tensor4all.Index(3; tags=["jp"])
+    bad = Tensor4all.Index(5; tags=["bad"])
+    missing = Tensor4all.Index(2; tags=["missing"])
+
+    data = reshape(collect(1.0:6.0), 2, 3)
+    handle = Ptr{Cvoid}(1)
+    tensor = Tensor4all.Tensor(data, [i, j]; backend_handle=handle)
+
+    replaced = Tensor4all.replaceind(tensor, i, ip)
+    @test Tensor4all.inds(replaced) == [ip, j]
+    @test Tensor4all.inds(tensor) == [i, j]
+    @test replaced.data == tensor.data
+    @test replaced.backend_handle == handle
+
+    @test Tensor4all.inds(Tensor4all.replaceind(tensor, i => ip)) == [ip, j]
+    @test Tensor4all.inds(Tensor4all.replaceinds(tensor, (i, j), (ip, jp))) == [ip, jp]
+    @test Tensor4all.inds(Tensor4all.replaceinds(tensor, i => ip, j => jp)) == [ip, jp]
+    @test Tensor4all.inds(Tensor4all.replaceind(tensor, missing, ip)) == [i, j]
+    @test Tensor4all.inds(Tensor4all.replaceinds(tensor, [missing], [ip])) == [i, j]
+    @test_throws ArgumentError Tensor4all.replaceind(tensor, i, bad)
+    @test_throws ArgumentError Tensor4all.replaceinds(tensor, (i,), (bad,))
+
+    mut = Tensor4all.Tensor(data, [i, j]; backend_handle=handle)
+    @test Tensor4all.replaceind!(mut, i, ip) === mut
+    @test Tensor4all.inds(mut) == [ip, j]
+    @test mut.data == data
+    @test mut.backend_handle == handle
+
+    mut2 = Tensor4all.Tensor(data, [i, j]; backend_handle=handle)
+    @test Tensor4all.replaceinds!(mut2, (i, j), (ip, jp)) === mut2
+    @test Tensor4all.inds(mut2) == [ip, jp]
+    @test mut2.data == data
+    @test mut2.backend_handle == handle
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Test
 using Tensor4all
 
 include("api/skeleton_alignment.jl")
+include("core/tensor.jl")
 include("core/tensor_arithmetic.jl")
 include("core/tensor_factorize.jl")
 include("core/tensor_contract.jl")


### PR DESCRIPTION
## Summary
- add ITensors-style `replaceind` / `replaceinds` support for `Tensor4all.Tensor`, including mutating `replaceind!` and `replaceinds!`
- align `Index` collection replacement semantics with pair notation, empty no-op calls, original-position multi-replacement, and dimension validation for present indices
- add focused regression coverage and document the mutating replace APIs in the core API reference

## Why
Issue #60 reported that `Tensor4all.Tensor` was missing `replaceind`, forcing downstream code to rebuild tensors manually just to swap index metadata. The root cause was that replacement helpers existed only for `AbstractVector{Index}`, and even there the semantics were narrower than the ITensors-compatible surface users expect.

## Impact
Downstream code can now use ITensors-style index replacement directly on `Tensor` values without touching dense storage, and package tests now lock those compatibility expectations in place.

## Validation
- `julia --startup-file=no --project=. test/core/index.jl`
- `julia --startup-file=no --project=. test/runtests.jl`
- `julia --startup-file=no --project=docs docs/make.jl`
- `julia --startup-file=no --project=. -e 'using Tensor4all; println("ok")'`

Fixes #60
