### PR TITLE
ci: Julia matrix uses lts and latest stable

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,14 +20,14 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - '1.10'
-          - '1.11'
+          - 'lts'
+          - '1'
         os:
           - ubuntu-latest
           - macos-latest
         include:
           - os: ubuntu-latest
-            julia-version: '1.10'
+            julia-version: 'lts'
             coverage: true
 
     steps:


### PR DESCRIPTION
## Summary

Updates the CI matrix to use `julia-actions/setup-julia` version specifiers:

- **`'lts'`** — current long-term support release
- **`'1'`** — latest stable 1.x

The coverage job remains **ubuntu-latest** + **lts** so Codecov still uploads a single representative build.

### Rationale

Avoids periodic workflow edits when Julia minors advance; trade-off is that CI resolves to newer patch/minor versions over time without a dedicated PR.

Made with [Cursor](https://cursor.com)