### PR TITLE
feat: extend ITensorCompat with prime/replaceprime/sim/adjoint/MPO(Vector{Tensor})/data/maxlinkdim

### DIFF
--- a/docs/plans/2026-04-15-tensornetworks-helper-implementation.md
+++ b/docs/plans/2026-04-15-tensornetworks-helper-implementation.md
@@ -1,0 +1,661 @@
+# TensorNetworks Helper Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the remaining `TensorNetworks` `SkeletonNotImplemented` surface with pure Julia helper implementations and a correctness-first `LinearOperator` application path, then port the decisive `tensor4all-rs` / `Quantics.jl` tests that should lock behavior.
+
+**Architecture:** Keep `TensorNetworks.TensorTrain` as the indexed chain type and implement the remaining helper surface in Julia on top of `Tensor` / `Index` metadata plus dense array operations. Pure metadata helpers should not call the C API. Numeric chain helpers should use `reshape`, `permutedims`, and `LinearAlgebra` factorization, not new C-API entry points. Use `Quantics.jl` as the primary semantic reference for chain helper behavior and `ITensorMPS.jl` as the natural Julia API reference for `findsite`, `findsites`, `replace_siteinds!`, and `apply`. If `src/TensorNetworks.jl` stops being comfortably reviewable, split it into `src/TensorNetworks/` with a soft cap of roughly 250-350 lines per file.
+
+**Tech Stack:** Julia, `LinearAlgebra`, existing `Tensor4all.Index` / `Tensor4all.Tensor` / `Tensor4all.SimpleTT`, Documenter.jl, reference checkouts `../Quantics.jl`, `../ITensorMPS.jl`, and `../tensor4all-rs`
+
+---
+
+## Reference checkpoints
+
+- `../ITensorMPS.jl/src/mps.jl:519-527`:
+  `replace_siteinds!` / `replace_siteinds` shape and mutating-vs-copy contract.
+- `../ITensorMPS.jl/src/abstractmps.jl:538-595`:
+  `findsite` / `findsites` public semantics.
+- `../ITensorMPS.jl/src/abstractmps.jl:653-680` and `../ITensorMPS.jl/src/mpo.jl:254-283`:
+  best available analogs for space/index ownership, but not a direct `set_*space!` equivalent.
+- `../ITensorMPS.jl/test/base/test_mps.jl:1218-1251`:
+  decisive `findsite` / `findsites` expectations for MPS and MPO.
+- `../ITensorMPS.jl/src/mpo.jl:598-614`:
+  natural Julia-facing `apply(A, ψ)` contract for MPO-on-MPS application.
+- `../Quantics.jl/src/tag.jl:14-63`:
+  tag-based site lookup semantics.
+- `../Quantics.jl/src/util.jl:263-327`:
+  `matchsiteinds`.
+- `../Quantics.jl/src/util.jl:436-556`:
+  `replace_siteinds_part!`, `rearrange_siteinds`, `makesitediagonal`, `extractdiagonal`.
+- `../Quantics.jl/test/util_tests.jl:89-301`:
+  minimal numerical checks worth porting.
+- `../tensor4all-rs/crates/tensor4all-quanticstransform/tests/integration_test.rs:367-2822`:
+  dense-matrix and basis-state operator tests worth translating to Julia.
+- `../tensor4all-rs/crates/tensor4all-quanticstransform/src/cumsum/tests/mod.rs:1-70`:
+  cumsum structure and validation checks.
+- `../tensor4all-rs/crates/tensor4all-quanticstransform/src/fourier/tests/mod.rs:1-111`:
+  fourier structure and validation checks.
+- `../tensor4all-rs/crates/tensor4all-quanticstransform/src/affine/tests/mod.rs:612-1038`:
+  affine correctness cases that should become Julia tests once `apply` is real.
+
+### Scope decisions
+
+- Do not add HDF5 C-API usage back. The pure Julia HDF5 extension stays as-is.
+- Do not add new C-API entry points for helper behavior that can be expressed with Julia tensor metadata and dense array algebra.
+- Every newly exported type and function touched by this plan needs a concise docstring.
+- If implementing these tasks pushes a single submodule file past the soft cap above, create a subdirectory and split by responsibility before adding more logic.
+- Tensor4all does not assign semantic meaning to prime level for operator I/O.
+- Therefore the public `set_input_space!`, `set_output_space!`, and `set_iospaces!`
+  APIs should accept explicit `Vector{Index}` arguments only, not `TensorTrain`.
+- If an operator is built from an MPO-like chain, the constructor or helper that
+  wraps that chain must receive explicit `input_indices` and `output_indices`.
+
+### Task 1: Lock the metadata helper semantics with focused tests
+
+**Files:**
+- Create: `test/tensornetworks/index_queries.jl`
+- Modify: `test/runtests.jl`
+
+**Step 1: Write the failing test**
+
+Create two small fixtures:
+
+- one MPS-like `TensorNetworks.TensorTrain` with one site index per tensor
+- one MPO-like `TensorNetworks.TensorTrain` with one unprimed and one primed site index per tensor
+
+Add checks modeled on `ITensorMPS.jl` and `Quantics.jl`:
+
+```julia
+@testset "TensorNetworks index queries" begin
+    TN = Tensor4all.TensorNetworks
+    ψ, sites, links = mps_fixture()
+    M, mpo_sites, mpo_links = mpo_fixture()
+
+    @test TN.findsite(ψ, sites[2]) == 2
+    @test TN.findsites(ψ, links[1]) == [1, 2]
+    @test TN.findallsites_by_tag(ψ; tag="x") == [1, 2, 3]
+    @test TN.findallsiteinds_by_tag(ψ; tag="x") == sites
+
+    @test TN.findsite(M, mpo_sites[2][1]) == 2
+    @test TN.findsite(M, mpo_sites[2][2]) == 2
+    @test TN.findsites(M, (mpo_sites[2][1], mpo_sites[3][2])) == [2, 3]
+
+    replaced = TN.replace_siteinds(ψ, sites, sim.(sites))
+    @test Tensor4all.inds(replaced[1])[1] == sim(sites[1])
+    @test Tensor4all.inds(ψ[1])[1] == sites[1]
+
+    ψcopy = deepcopy_tt(ψ)
+    TN.replace_siteinds!(ψcopy, sites, sim.(sites))
+    @test Tensor4all.inds(ψcopy[2])[1] == sim(sites[2])
+end
+```
+
+Also add argument-error cases:
+
+- invalid tag containing `=`
+- replacement length mismatch
+- lookup target not found
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+julia --startup-file=no --project=. test/runtests.jl
+```
+
+Expected: FAIL because the current methods still throw `SkeletonNotImplemented`.
+
+**Step 3: Write minimal implementation**
+
+No implementation in this task.
+
+**Step 4: Run test to confirm the failure is the intended one**
+
+Run:
+
+```bash
+julia --startup-file=no --project=. test/runtests.jl
+```
+
+Expected: FAIL only on the new helper expectations.
+
+**Step 5: Commit**
+
+```bash
+git add test/tensornetworks/index_queries.jl test/runtests.jl
+git commit -m "test: lock tensornetworks metadata helper semantics"
+```
+
+### Task 2: Implement structural introspection and metadata helpers
+
+**Files:**
+- Modify: `src/TensorNetworks.jl`
+- Or split into:
+  - Create: `src/TensorNetworks/types.jl`
+  - Create: `src/TensorNetworks/index_queries.jl`
+  - Create: `src/TensorNetworks/siteops.jl`
+  - Modify: `src/TensorNetworks.jl`
+
+**Step 1: Write the failing test**
+
+Use the tests from Task 1.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+julia --startup-file=no --project=. test/runtests.jl
+```
+
+Expected: FAIL on `findsite`, `findsites`, `findallsiteinds_by_tag`, `findallsites_by_tag`, `replace_siteinds!`, `replace_siteinds`, and `replace_siteinds_part!`.
+
+**Step 3: Write minimal implementation**
+
+Implement internal utilities first:
+
+- `_siteinds_per_tensor(tt)`:
+  return the physical indices for each tensor, excluding chain links.
+- `_linkinds(tt)`:
+  infer adjacent shared indices between neighboring tensors.
+- `_is_mps_like(tt)` / `_is_mpo_like(tt)`:
+  classify tensors by physical-site count per core.
+- `_find_tensor_sites(tt, target)`:
+  match a single `Index`, tuple of `Index`, or `Tensor`.
+
+Then implement:
+
+- `findsite`
+- `findsites`
+- `findallsiteinds_by_tag`
+- `findallsites_by_tag`
+- `replace_siteinds!`
+- `replace_siteinds`
+- `replace_siteinds_part!`
+
+Required semantics:
+
+- follow the `ITensorMPS.jl` mutating/non-mutating split
+- preserve tensor data unless the index metadata itself changes
+- validate replacement lengths and not-found cases with actionable messages
+- treat tags the way `Quantics.jl/src/tag.jl` does:
+  `x=1`, `x=2`, ... search in order, error on duplicates, empty result allowed
+
+While touching exports, add concise docstrings for each exported helper.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+julia --startup-file=no --project=. test/runtests.jl
+```
+
+Expected: PASS for the new metadata-helper tests.
+
+**Step 5: Commit**
+
+```bash
+git add src/TensorNetworks.jl src/TensorNetworks test/tensornetworks/index_queries.jl
+git commit -m "feat: implement tensornetworks metadata helpers"
+```
+
+### Task 3: Port and implement `matchsiteinds`
+
+**Files:**
+- Create: `test/tensornetworks/matchsiteinds.jl`
+- Modify: `test/runtests.jl`
+- Modify: `src/TensorNetworks.jl`
+- Or create: `src/TensorNetworks/matchsiteinds.jl`
+
+**Step 1: Write the failing test**
+
+Translate the decisive `Quantics.jl/test/util_tests.jl:89-134` cases:
+
+```julia
+@testset "TensorNetworks.matchsiteinds" begin
+    ψ_sparse, sparse_sites, full_sites = sparse_mps_fixture()
+    ψ_full = Tensor4all.TensorNetworks.matchsiteinds(ψ_sparse, full_sites)
+
+    @test dense_mps_values(ψ_full, full_sites) ==
+        dense_mps_values_with_inserted_singletons(ψ_sparse, sparse_sites, full_sites)
+
+    M_sparse, sparse_sites, full_sites = sparse_mpo_fixture()
+    M_full = Tensor4all.TensorNetworks.matchsiteinds(M_sparse, full_sites)
+
+    @test dense_mpo_matrix(M_full, full_sites) == dense_mpo_matrix_with_inserted_identity(
+        M_sparse,
+        sparse_sites,
+        full_sites,
+    )
+end
+```
+
+Keep the fixtures tiny, for example 2-3 sites only.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+julia --startup-file=no --project=. test/runtests.jl
+```
+
+Expected: FAIL because `matchsiteinds` still throws.
+
+**Step 3: Write minimal implementation**
+
+Port the `Quantics.jl` algorithm, but rewrite it for `Tensor4all.Tensor`:
+
+- normalize candidate sites with `noprime`
+- compute the current site positions in the requested ordering
+- reject non-ascending order unless reversing is explicitly handled
+- synthesize missing identity or basis tensors for gaps
+- rebuild the chain with consistent link dimensions
+
+Prefer tiny internal array helpers over generic tensor-contraction abstractions. Keep the first implementation correctness-first, not optimized.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+julia --startup-file=no --project=. test/runtests.jl
+```
+
+Expected: PASS for the `matchsiteinds` tests.
+
+**Step 5: Commit**
+
+```bash
+git add src/TensorNetworks.jl src/TensorNetworks test/tensornetworks/matchsiteinds.jl test/runtests.jl
+git commit -m "feat: implement tensornetworks matchsiteinds"
+```
+
+### Task 4: Port and implement `rearrange_siteinds`, `makesitediagonal`, and `extractdiagonal`
+
+**Files:**
+- Create: `test/tensornetworks/site_transforms.jl`
+- Modify: `test/runtests.jl`
+- Modify: `src/TensorNetworks.jl`
+- Or create:
+  - `src/TensorNetworks/dense_chain_ops.jl`
+  - `src/TensorNetworks/site_transforms.jl`
+
+**Step 1: Write the failing test**
+
+Translate the small but decisive `Quantics.jl/test/util_tests.jl:177-301` cases:
+
+- rearrange `[[x1], [y1], [x2], [y2]] -> [[x1, y1], [x2, y2]]`
+- rearrange back and verify exact roundtrip
+- make a diagonal MPO from a tiny MPS and verify only diagonal entries survive
+- extract the diagonal back and verify exact recovery
+
+Representative checks:
+
+```julia
+@testset "TensorNetworks site transforms" begin
+    ψ, sites = xy_fixture()
+
+    fused_sites = [[sites.x[1], sites.y[1]], [sites.x[2], sites.y[2]]]
+    ψ_fused = Tensor4all.TensorNetworks.rearrange_siteinds(ψ, fused_sites)
+    ψ_back = Tensor4all.TensorNetworks.rearrange_siteinds(ψ_fused, [[s] for s in vcat(sites.x, sites.y)])
+    @test dense_tt(ψ) == dense_tt(ψ_back)
+
+    Mdiag = Tensor4all.TensorNetworks.makesitediagonal(ψ, "x")
+    @test dense_diagonal_entries_match(ψ, Mdiag, "x")
+    @test Tensor4all.TensorNetworks.extractdiagonal(Mdiag, "x") == ψ
+end
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+julia --startup-file=no --project=. test/runtests.jl
+```
+
+Expected: FAIL because these helpers still throw.
+
+**Step 3: Write minimal implementation**
+
+Implement dense internal helpers:
+
+- `_contract_dense_chain_prefix!`
+- `_factorize_tensor_to_chain`
+- `_tensor_as_diagonal`
+- `_extract_dense_diagonal`
+
+Then implement:
+
+- `rearrange_siteinds`
+- `makesitediagonal`
+- `extractdiagonal`
+
+Recommended approach:
+
+- contract only as much of the chain as needed
+- factorize back with `qr` or `svd` from `LinearAlgebra`
+- preserve site ordering exactly as requested
+- keep dimensions and index IDs stable unless the API explicitly creates primed copies
+
+If this logic pushes the module past the soft cap, split it before continuing.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+julia --startup-file=no --project=. test/runtests.jl
+```
+
+Expected: PASS for the new site-transform tests.
+
+**Step 5: Commit**
+
+```bash
+git add src/TensorNetworks.jl src/TensorNetworks test/tensornetworks/site_transforms.jl test/runtests.jl
+git commit -m "feat: implement tensornetworks site transforms"
+```
+
+### Task 5: Keep `set_*space!` explicit and implement exact `apply`
+
+**Files:**
+- Create: `test/tensornetworks/apply.jl`
+- Modify: `test/runtests.jl`
+- Modify: `src/TensorNetworks.jl`
+- Or create: `src/TensorNetworks/operators.jl`
+
+**Step 1: Write the failing test**
+
+Add three layers of tests:
+
+1. space-binding behavior
+2. exact application of a hand-written identity or diagonal MPO to a tiny MPS
+3. helpful argument errors
+
+Representative tests:
+
+```julia
+@testset "TensorNetworks operator binding and apply" begin
+    TN = Tensor4all.TensorNetworks
+    ψ, sites = basis_state_fixture(0b10)
+    op = identity_linear_operator(sites)
+
+    TN.set_iospaces!(op, sites)
+    @test op.true_input == Vector{Union{Tensor4all.Index, Nothing}}(sites)
+    @test op.true_output == Vector{Union{Tensor4all.Index, Nothing}}(sites)
+
+    ϕ = TN.apply(op, ψ)
+    @test dense_tt(ϕ) == dense_tt(ψ)
+
+    bad = mpo_like_fixture_with_wrong_length()
+    @test_throws DimensionMismatch TN.apply(op, bad)
+end
+```
+
+Keep the first implementation scope narrow:
+
+- support MPO-like operator on MPS-like state
+- exact or `:naive` algorithm only
+- no truncation heuristics yet
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+julia --startup-file=no --project=. test/runtests.jl
+```
+
+Expected: FAIL because TT overloads still throw and `apply` is unimplemented.
+Expected: FAIL because `apply` is unimplemented and the explicit binding path is not yet fully exercised.
+
+**Step 3: Write minimal implementation**
+
+For the public binding API:
+
+- keep only the explicit index-vector methods:
+  - `set_input_space!(op, input_indices::Vector{Index})`
+  - `set_output_space!(op, output_indices::Vector{Index})`
+  - `set_iospaces!(op, input_indices::Vector{Index}, output_indices::Vector{Index}=input_indices)`
+- do not add public `TensorTrain` overloads for these setters
+- if wrapping an MPO-like chain as a `LinearOperator`, require explicit
+  `input_indices` and `output_indices` at construction time
+- document clearly that prime level is not used to infer operator domain/codomain
+
+For `apply`:
+
+- validate operator/state lengths and site compatibility
+- require explicit `true_input` and `true_output` binding before execution
+- if either side is unset, throw an actionable `ArgumentError` telling the user to call `set_input_space!`, `set_output_space!`, or `set_iospaces!`
+- never infer input/output role from prime levels
+
+For `apply`:
+
+- validate operator/state lengths and site compatibility
+- contract each MPO/MPS site pair exactly using dense array algebra
+- factorize back to an MPS-like chain
+- return a `TensorTrain` with user-facing output indices and the same chain limits as the input
+
+Use `ITensorMPS.jl/src/mpo.jl:598-614` as the API reference and the existing `SimpleTT` contraction code as a shape/algebra reference when useful.
+
+Add concise docstrings to the overloads and to `apply`.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+julia --startup-file=no --project=. test/runtests.jl
+```
+
+Expected: PASS for the new operator-binding and exact-apply tests.
+
+**Step 5: Commit**
+
+```bash
+git add src/TensorNetworks.jl src/TensorNetworks test/tensornetworks/apply.jl test/runtests.jl
+git commit -m "feat: implement tensornetworks linear operator apply"
+```
+
+### Task 6: Port the decisive `tensor4all-rs` `QuanticsTransform` tests in phases
+
+**Files:**
+- Create: `test/quanticstransform/numerics.jl`
+- Modify: `test/runtests.jl`
+- Modify: `src/QuanticsTransform.jl`
+- Modify: `src/TensorNetworks.jl`
+
+**Step 1: Write the failing test**
+
+Start with the smallest correctness locks from Rust:
+
+- shift all values:
+  `integration_test.rs:903`
+- flip all values:
+  `integration_test.rs:827`
+- phase rotation on basis states:
+  `integration_test.rs:1513-1667`
+- open-boundary shift / flip edge cases:
+  `integration_test.rs:1277-1412`
+- cumsum and fourier structure/validation:
+  `src/cumsum/tests/mod.rs:1-70`
+  `src/fourier/tests/mod.rs:1-111`
+
+Only after those pass, add affine cases:
+
+- affine identity / shift / rectangular / light-cone:
+  `src/affine/tests/mod.rs:612-686`
+- affine unitarity and matrix-match checks:
+  `src/affine/tests/mod.rs:694-1038`
+
+Representative test shape:
+
+```julia
+@testset "QuanticsTransform numerics" begin
+    ψ = basis_state_tt(0b001)
+
+    shift = Tensor4all.QuanticsTransform.shift_operator(3, 1)
+    Tensor4all.TensorNetworks.set_iospaces!(shift, ψ)
+    @test basis_index_of(Tensor4all.TensorNetworks.apply(shift, ψ)) == 0b010
+
+    flip = Tensor4all.QuanticsTransform.flip_operator(3)
+    Tensor4all.TensorNetworks.set_iospaces!(flip, ψ)
+    @test basis_index_of(Tensor4all.TensorNetworks.apply(flip, ψ)) == 0b111
+end
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+julia --startup-file=no --project=. test/runtests.jl
+```
+
+Expected: FAIL because the operators are still metadata-only placeholders.
+
+**Step 3: Write minimal implementation**
+
+Implement real operator construction incrementally:
+
+- shift
+- flip
+- phase rotation
+- cumsum
+- fourier
+- affine
+- binaryop
+
+Do not jump to affine first. The natural order is:
+
+1. basis-preserving permutation operators
+2. diagonal/phase operators
+3. cumulative/triangular operators
+4. fourier structure and inverse checks
+5. affine and binaryop
+
+Each constructor should return a real `TensorNetworks.LinearOperator` with a concrete MPO and binding metadata, not just a `metadata` placeholder.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+julia --startup-file=no --project=. test/runtests.jl
+```
+
+Expected: PASS for the translated Rust test subset now covered by Julia.
+
+**Step 5: Commit**
+
+```bash
+git add src/QuanticsTransform.jl src/TensorNetworks.jl test/quanticstransform/numerics.jl test/runtests.jl
+git commit -m "feat: implement quantics transform operators with translated tests"
+```
+
+### Task 7: Align docs, exported docstrings, and public status notes
+
+**Files:**
+- Modify: `README.md`
+- Modify: `AGENTS.md`
+- Modify: `docs/src/index.md`
+- Modify: `docs/src/modules.md`
+- Modify: `docs/src/api.md`
+- Modify: any touched `src/*.jl` files
+
+**Step 1: Write the failing test**
+
+No new unit test. Verification is docs and package-loading.
+
+**Step 2: Run verification to identify gaps**
+
+Run:
+
+```bash
+rg -n "SkeletonNotImplemented|placeholder|review phase|Phase 2 helper surface" README.md AGENTS.md docs/src src
+```
+
+Expected: find stale wording that still implies the helper surface is unimplemented after Tasks 2-6.
+
+**Step 3: Write minimal implementation**
+
+Update docs so they say:
+
+- which helper APIs are now implemented
+- which operator families are implemented and tested
+- what still remains intentionally unimplemented
+
+While touching exported functions and structs, add concise docstrings:
+
+- one-sentence summary
+- current implemented behavior
+- short example only when deterministic and cheap
+
+Do not write expansive narrative docstrings.
+
+**Step 4: Run verification to verify it passes**
+
+Run:
+
+```bash
+julia --startup-file=no --project=docs docs/make.jl
+julia --startup-file=no --project=. test/runtests.jl
+julia --startup-file=no --project=. -e 'using Tensor4all'
+```
+
+Expected: all PASS.
+
+**Step 5: Commit**
+
+```bash
+git add README.md AGENTS.md docs/src src
+git commit -m "docs: align helper and operator docs with implementation"
+```
+
+### Task 8: Final verification and branch hygiene
+
+**Files:**
+- Test: `test/runtests.jl`
+
+**Step 1: Run the full package test suite**
+
+Run:
+
+```bash
+julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
+```
+
+Expected: PASS.
+
+**Step 2: Run docs build**
+
+Run:
+
+```bash
+julia --startup-file=no --project=docs docs/make.jl
+```
+
+Expected: PASS.
+
+**Step 3: Inspect the diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat
+```
+
+Expected: only the intended helper, operator, test, and docs files are modified.
+
+**Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "feat: implement remaining tensornetworks helpers and operator path"
+```

--- a/docs/plans/2026-04-26-ITensorCompat-extension-design.md
+++ b/docs/plans/2026-04-26-ITensorCompat-extension-design.md
@@ -1,0 +1,51 @@
+# ITensorCompat Extension Design
+
+## Goal
+
+Extend `Tensor4all.jl`'s `ITensorCompat` module with the missing MPS/MPO operations needed to migrate `BubbleTeaCI.jl` and `QuanticsNEGF.jl` away from `ITensors.jl`/`ITensorMPS.jl`.
+
+## Added API Surface
+
+### Layer 1: MPS/MPO constructors and site-index operations
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `MPO(tensors::Vector{Tensor})` | constructor | Build MPO from tensor list; each tensor must have exactly 2 site indices |
+| `prime(m::MPS)` | `MPS` | Return new MPS with siteinds' prime level +1 (tensor data shared) |
+| `prime(m::MPO)` | `MPO` | Return new MPO with siteinds' prime level +1 |
+| `prime!(m::MPS)` | `MPS` | In-place siteinds prime +1 |
+| `prime!(m::MPO)` | `MPO` | In-place siteinds prime +1 |
+| `replaceprime(m::MPS, pairs...)` | `MPS` | Replace prime levels in siteinds: `replaceprime(m, 1=>0)` |
+| `replaceprime(m::MPO, pairs...)` | `MPO` | Same for MPO |
+| `sim(siteinds, m::MPS)` | `Vector{Index}` | Return cloned siteinds with fresh IDs |
+| `sim(siteinds, m::MPO)` | `Vector{Vector{Index}}` | Same for MPO (per-site index list) |
+
+### Layer 2: Index `'` operator
+
+| Function | Description |
+|----------|-------------|
+| `Base.adjoint(idx::Tensor4all.Index)` | `idx'` returns `prime(idx)` |
+
+### Layer 3: Utility accessors
+
+| Function | Description |
+|----------|-------------|
+| `maxlinkdim(m::MPS)` | = `rank(m)` alias |
+| `maxlinkdim(m::MPO)` | = `rank(m)` alias |
+| `data(m::MPS)` | `m.tt.data` — raw tensor vector |
+| `data(w::MPO)` | `w.tt.data` — raw tensor vector |
+| `data(tt::TensorTrain)` | `tt.data` — raw tensor vector |
+
+## Design Decisions
+
+### `prime(mps)` returns MPS, not Index vector
+Matches ITensorMPS behavior: returns a new MPS wrapping the same internal tensors but with siteinds' prime levels incremented.
+
+### `replaceprime` semantics
+Scans siteinds and replaces any index whose `plev` matches the `old` value to have `new` value. Applied to all site groups (for MPO, applied to all indices in each site group).
+
+### `Base.adjoint` on Index
+Julia's `'` calls `adjoint()`. Index is not a linear operator, so defining `adjoint` as `prime` has no mathematical conflict. This pattern matches ITensors.jl's own `idx'` convention.
+
+### `data()` accessor
+Provides a uniform way to access the underlying `Vector{Tensor}` for inspection/debugging, matching `ITensors.data()` which accesses the raw storage.

--- a/docs/superpowers/plans/2026-04-26-ITensorCompat-extension-plan.md
+++ b/docs/superpowers/plans/2026-04-26-ITensorCompat-extension-plan.md
@@ -1,0 +1,546 @@
+# ITensorCompat Extension Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `prime/prime!`, `replaceprime`, `sim(siteinds,...)`, `MPO(Vector{Tensor})`, `maxlinkdim`, `data()`, and `Base.adjoint(::Index)` to `Tensor4all.jl`'s `ITensorCompat` module.
+
+**Architecture:** `MPO(Vector{Tensor})`, `prime/prime!/replaceprime/sim(siteinds)` added to `src/ITensorCompat.jl`. `Base.adjoint(::Index)` added to `src/Core/Index.jl`. All new tests in one file.
+
+**Tech Stack:** Julia, Tensor4all.jl (ITensorCompat, TensorNetworks, Core.Index)
+
+---
+
+## File Map
+
+- Modify: `Tensor4all.jl/src/ITensorCompat.jl` — Layer 1 & 3 functions
+- Modify: `Tensor4all.jl/src/Core/Index.jl` — `Base.adjoint(idx::Index)`
+- Create: `Tensor4all.jl/test/itensorcompat/operator_overloads.jl` — new tests
+- Modify: `Tensor4all.jl/test/runtests.jl` — add include
+
+---
+
+### Task 1: `maxlinkdim` and `data()` accessors
+
+**Files:**
+- Modify: `src/ITensorCompat.jl`
+- Create: `test/itensorcompat/operator_overloads.jl`
+- Modify: `test/runtests.jl`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/itensorcompat/operator_overloads.jl`:
+```julia
+using Test
+using Tensor4all
+
+const IC = Tensor4all.ITensorCompat
+const TN = Tensor4all.TensorNetworks
+
+@testset "maxlinkdim" begin
+    sites = [Index(2; tags=["s$n"]) for n in 1:3]
+    blocks = [
+        reshape([1.0, 0.0, 0.0, 1.0], 1, 2, 3),
+        reshape([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2, 4),
+        reshape([1.0, 0.0, 0.0, -1.0], 4, 2, 1),
+    ]
+    m = IC.MPS(blocks, sites)
+    @test IC.maxlinkdim(m) == 4
+
+    blocks_mpo = [
+        reshape(collect(1.0:12.0), 1, 2, 2, 3),
+        reshape(collect(1.0:24.0), 3, 2, 2, 1),
+    ]
+    input = [Index(2; tags=["in$n"]) for n in 1:2]
+    output = [Index(2; tags=["out$n"]) for n in 1:2]
+    w = IC.MPO(blocks_mpo, input, output)
+    @test IC.maxlinkdim(w) == 3
+end
+
+@testset "data accessor" begin
+    sites = [Index(2; tags=["s$n"]) for n in 1:2]
+    blocks = [
+        reshape([1.0, 0.0, 0.0, 1.0], 1, 2, 2),
+        reshape([2.0, 0.0, 0.0, -1.0], 2, 2, 1),
+    ]
+    m = IC.MPS(blocks, sites)
+    d = IC.data(m)
+    @test d isa Vector{Tensor4all.Tensor}
+    @test length(d) == 2
+
+    input = [Index(2; tags=["in$n"]) for n in 1:1]
+    output = [Index(2; tags=["out$n"]) for n in 1:1]
+    blocks_mpo = [reshape([1.0, 0.0, 0.0, -1.0], 1, 2, 2, 1)]
+    w = IC.MPO(blocks_mpo, input, output)
+    dw = IC.data(w)
+    @test dw isa Vector{Tensor4all.Tensor}
+    @test length(dw) == 1
+
+    tt = TN.TensorTrain([Tensor(1.0)])
+    dtt = IC.data(tt)
+    @test dtt isa Vector{Tensor4all.Tensor}
+    @test length(dtt) == 1
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `julia --project=. test/itensorcompat/operator_overloads.jl`
+Expected: 2 failures — `maxlinkdim` not defined, `data` not defined
+
+  - [ ] **Step 3: Write minimal implementation with docstrings**
+
+Add to `src/ITensorCompat.jl` before the closing `end`:
+
+```julia
+"""
+    maxlinkdim(m::MPS) -> Int
+    maxlinkdim(w::MPO) -> Int
+
+Return the maximum bond dimension (link index dimension) of `m` or `w`.
+Equivalent to `rank(m)` / `rank(w)`. Compatible with `ITensorMPS.maxlinkdim`.
+"""
+maxlinkdim(m::MPS) = rank(m)
+maxlinkdim(w::MPO) = rank(w)
+
+"""
+    data(m::MPS) -> Vector{Tensor}
+    data(w::MPO) -> Vector{Tensor}
+    data(tt::TensorTrain) -> Vector{Tensor}
+
+Return the underlying tensor storage vector. Compatible with `ITensors.data`.
+"""
+data(m::MPS) = m.tt.data
+data(w::MPO) = w.tt.data
+data(tt::TensorTrain) = tt.data
+```
+
+Add `maxlinkdim` and `data` to the export block:
+
+```julia
+export MPS, MPO
+export siteinds, linkinds, linkdims, rank, maxlinkdim
+export add, dag, dot, evaluate, inner, norm, replace_siteinds, replace_siteinds!, to_dense
+export fixinds, suminds, projectinds, scalar
+export orthogonalize!, truncate!
+export prime, prime!, replaceprime
+export data
+```
+
+- [ ] **Step 4: Add test to runtests.jl**
+
+Add after the `bubbleteaci_workflow.jl` line in `test/runtests.jl`:
+
+```julia
+include("itensorcompat/operator_overloads.jl")
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `julia --project=. test/itensorcompat/operator_overloads.jl`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ITensorCompat.jl test/itensorcompat/operator_overloads.jl test/runtests.jl
+git commit -m "feat: add maxlinkdim and data() to ITensorCompat"
+```
+
+---
+
+### Task 2: `MPO(Vector{Tensor})` constructor
+
+**Files:**
+- Modify: `src/ITensorCompat.jl`
+- Modify: `test/itensorcompat/operator_overloads.jl`
+
+- [ ] **Step 1: Add failing test**
+
+Append to `test/itensorcompat/operator_overloads.jl`:
+
+```julia
+@testset "MPO from Tensor vector" begin
+    i = Index(2; tags=["i"])
+    o = Index(2; tags=["o"])
+    l1 = Index(3; tags=["Link", "l=1"])
+    t1 = Tensor(reshape(collect(1.0:12.0), 2, 2, 3), [i, o, l1])
+    t2 = Tensor(reshape(collect(1.0:6.0), 3, 2, 2), [l1, i, o])
+    w = IC.MPO([t1, t2])
+    @test length(w) == 2
+    @test length(IC.siteinds(w)) == 2
+    @test IC.siteinds(w)[1] == [i, o]
+    @test IC.siteinds(w)[2] == [i, o]
+    @test IC.data(w)[1] === t1
+
+    # error case: tensor with wrong number of site indices
+    t_bad = Tensor(reshape(collect(1.0:4.0), 2, 2), [i, o])
+    @test_throws ArgumentError IC.MPO([t_bad])
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `julia --project=. test/itensorcompat/operator_overloads.jl`
+Expected: FAIL — `MethodError: no method matching MPO(::Vector{Tensor})`
+
+  - [ ] **Step 3: Write minimal implementation with docstring**
+
+Add after the existing `MPO(blocks, input_sites, output_sites)` in `src/ITensorCompat.jl`:
+
+```julia
+"""
+    MPO(tensors::Vector{Tensor})
+
+Construct an MPO from an existing vector of `Tensor4all.Tensor` objects.
+Each tensor must have exactly two site indices. Compatible with the ITensorMPS
+`MPO(::Vector{ITensor})` constructor.
+"""
+function MPO(tensors::Vector{Tensor})
+    isempty(tensors) && throw(ArgumentError("MPO tensor vector must not be empty"))
+    groups = [Tensor.inds(t) for t in tensors]
+    for (position, group) in pairs(groups)
+        length(group) == 2 || throw(ArgumentError(
+            "MPO expects exactly two site indices at tensor $position, got $(length(group))",
+        ))
+    end
+    return MPO(TensorTrain(tensors))
+end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `julia --project=. test/itensorcompat/operator_overloads.jl`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ITensorCompat.jl test/itensorcompat/operator_overloads.jl
+git commit -m "feat: add MPO(Vector{Tensor}) constructor to ITensorCompat"
+```
+
+---
+
+### Task 3: `prime`, `prime!`, and `replaceprime` on MPS/MPO
+
+**Files:**
+- Modify: `src/ITensorCompat.jl`
+- Modify: `test/itensorcompat/operator_overloads.jl`
+
+- [ ] **Step 1: Add failing test**
+
+Append to `test/itensorcompat/operator_overloads.jl`:
+
+```julia
+@testset "prime/prime! on MPS" begin
+    sites = [Index(2; tags=["s$n"]) for n in 1:2]
+    blocks = [
+        reshape([1.0, 0.0, 0.0, 1.0], 1, 2, 2),
+        reshape([2.0, 0.0, 0.0, -1.0], 2, 2, 1),
+    ]
+    m = IC.MPS(blocks, sites)
+
+    mp = IC.prime(m)
+    @test IC.siteinds(mp)[1].plev == 1
+    @test IC.siteinds(m)[1].plev == 0  # original unchanged
+    @test mp[1].data === m[1].data     # tensor data shared
+
+    IC.prime!(m)
+    @test IC.siteinds(m)[1].plev == 1
+
+    mp2 = IC.prime(m, 2)
+    @test IC.siteinds(mp2)[1].plev == 3
+end
+
+@testset "prime/prime! on MPO" begin
+    i = Index(2; tags=["i"])
+    o = Index(2; tags=["o"])
+    l = Index(3; tags=["Link", "l=1"])
+    t1 = Tensor(reshape(collect(1.0:12.0), 2, 2, 3), [i, o, l])
+    t2 = Tensor(reshape(collect(1.0:6.0), 3, 2, 2), [l, i, o])
+    w = IC.MPO([t1, t2])
+
+    wp = IC.prime(w)
+    @test all(idx.plev == 1 for idx in Iterators.flatten(IC.siteinds(wp)))
+    @test all(idx.plev == 0 for idx in Iterators.flatten(IC.siteinds(w)))
+
+    IC.prime!(w)
+    @test all(idx.plev == 1 for idx in Iterators.flatten(IC.siteinds(w)))
+end
+
+@testset "replaceprime on MPS" begin
+    sites = [Index(2; tags=["s$n"], plev=2) for n in 1:2]
+    blocks = [
+        reshape([1.0, 0.0, 0.0, 1.0], 1, 2, 2),
+        reshape([2.0, 0.0, 0.0, -1.0], 2, 2, 1),
+    ]
+    m = IC.MPS(blocks, sites)
+    mr = IC.replaceprime(m, 2 => 0)
+    @test IC.siteinds(mr)[1].plev == 0
+    @test IC.siteinds(m)[1].plev == 2   # original unchanged
+end
+
+@testset "replaceprime on MPO" begin
+    i = Index(2; tags=["i"], plev=1)
+    o = Index(2; tags=["o"], plev=1)
+    l = Index(3; tags=["Link", "l=1"])
+    t1 = Tensor(reshape(collect(1.0:12.0), 2, 2, 3), [i, o, l])
+    t2 = Tensor(reshape(collect(1.0:6.0), 3, 2, 2), [l, i, o])
+    w = IC.MPO([t1, t2])
+    wr = IC.replaceprime(w, 1 => 0)
+    @test all(idx.plev == 0 for idx in Iterators.flatten(IC.siteinds(wr)))
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `julia --project=. test/itensorcompat/operator_overloads.jl`
+Expected: 4 failures — `prime`, `prime!`, `replaceprime` not defined
+
+  - [ ] **Step 3: Write minimal implementation with docstrings**
+
+Each new function must have a docstring. Add to `src/ITensorCompat.jl`:
+
+```julia
+"""
+    prime(m::MPS, n::Integer=1) -> MPS
+    prime(w::MPO, n::Integer=1) -> MPO
+
+Return a copy of `m`/`w` with site index prime levels increased by `n`.
+Tensor data is shared (not copied). Compatible with `ITensorMPS.prime`.
+"""
+function prime(m::MPS, n::Integer=1)
+    sites = siteinds(m)
+    primed = prime.(sites, Ref(n))
+    tt = TensorNetworks.replace_siteinds(m.tt, sites, primed)
+    return MPS(tt)
+end
+
+function prime(w::MPO, n::Integer=1)
+    groups = TensorNetworks.siteinds(w.tt)
+    flat_old = reduce(vcat, groups)
+    flat_new = [prime(idx, n) for idx in flat_old]
+    tt = TensorNetworks.replace_siteinds(w.tt, flat_old, flat_new)
+    return MPO(tt)
+end
+
+function prime!(m::MPS, n::Integer=1)
+    sites = siteinds(m)
+    primed = prime.(sites, Ref(n))
+    TensorNetworks.replace_siteinds!(m.tt, sites, primed)
+    return m
+end
+
+function prime!(w::MPO, n::Integer=1)
+    groups = TensorNetworks.siteinds(w.tt)
+    flat_old = reduce(vcat, groups)
+    flat_new = [prime(idx, n) for idx in flat_old]
+    TensorNetworks.replace_siteinds!(w.tt, flat_old, flat_new)
+    return w
+end
+
+"""
+    replaceprime(m::MPS, pairs::Pair{Int,Int}...) -> MPS
+    replaceprime(w::MPO, pairs::Pair{Int,Int}...) -> MPO
+
+Replace prime levels in site indices of `m`/`w` according to `pairs`.
+Each pair `old => new` replaces indices with `plev == old` to `plev == new`.
+Compatible with `ITensorMPS.replaceprime`.
+"""
+function replaceprime(m::MPS, pairs::Pair{Int,Int}...)
+    sites = siteinds(m)
+    mapped = map(sites) do idx
+        for (old, new) in pairs
+            plev(idx) == old && return setprime(idx, new)
+        end
+        return idx
+    end
+    tt = TensorNetworks.replace_siteinds(m.tt, sites, mapped)
+    return MPS(tt)
+end
+
+function replaceprime(w::MPO, pairs::Pair{Int,Int}...)
+    groups = TensorNetworks.siteinds(w.tt)
+    mapped = map(groups) do group
+        map(group) do idx
+            for (old, new) in pairs
+                plev(idx) == old && return setprime(idx, new)
+            end
+            return idx
+        end
+    end
+    flat_old = reduce(vcat, groups)
+    flat_new = reduce(vcat, mapped)
+    tt = TensorNetworks.replace_siteinds(w.tt, flat_old, flat_new)
+    return MPO(tt)
+end
+```
+
+Note: `prime` for Index and `setprime` for Index are already available from Tensor4all.Core (used via `import ..Tensor4all: ...`). But since ITensorCompat doesn't import them yet, add them to the existing import line:
+
+```julia
+import ..Tensor4all: Index, Tensor, dim, inds, rank, scalar, prime, setprime
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `julia --project=. test/itensorcompat/operator_overloads.jl`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ITensorCompat.jl test/itensorcompat/operator_overloads.jl
+git commit -m "feat: add prime/prime!/replaceprime to ITensorCompat"
+```
+
+---
+
+### Task 4: `sim(siteinds, ...)` on MPS/MPO
+
+**Files:**
+- Modify: `src/ITensorCompat.jl`
+- Modify: `test/itensorcompat/operator_overloads.jl`
+
+- [ ] **Step 1: Add failing test**
+
+Append to `test/itensorcompat/operator_overloads.jl`:
+
+```julia
+@testset "sim(siteinds, ...) on MPS" begin
+    sites = [Index(2; tags=["s$n"], plev=n) for n in 1:2]
+    blocks = [
+        reshape([1.0, 0.0, 0.0, 1.0], 1, 2, 2),
+        reshape([2.0, 0.0, 0.0, -1.0], 2, 2, 1),
+    ]
+    m = IC.MPS(blocks, sites)
+    new_sites = IC.sim(IC.siteinds, m)
+    @test new_sites isa Vector{Tensor4all.Index}
+    @test length(new_sites) == 2
+    @test dim.(new_sites) == dim.(sites)
+    @test Tensor4all.tags.(new_sites) == Tensor4all.tags.(sites)
+    @test plev.(new_sites) == plev.(sites)
+    @test id.(new_sites) != id.(sites)  # fresh IDs
+end
+
+@testset "sim(siteinds, ...) on MPO" begin
+    i = Index(2; tags=["i"])
+    o = Index(2; tags=["o"])
+    l = Index(3; tags=["Link", "l=1"])
+    t1 = Tensor(reshape(collect(1.0:12.0), 2, 2, 3), [i, o, l])
+    t2 = Tensor(reshape(collect(1.0:6.0), 3, 2, 2), [l, i, o])
+    w = IC.MPO([t1, t2])
+    new_sites = IC.sim(IC.siteinds, w)
+    @test new_sites isa Vector{Vector{Tensor4all.Index}}
+    @test length(new_sites) == 2
+    @test all(length(g) == 2 for g in new_sites)
+    @test id.(vcat(new_sites...)) != id.(vcat(i, o, i, o))
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `julia --project=. test/itensorcompat/operator_overloads.jl`
+Expected: FAIL — `MethodError: no method matching sim(::typeof(siteinds), ::MPS)`
+
+  - [ ] **Step 3: Write minimal implementation with docstring**
+
+Add to `src/ITensorCompat.jl`:
+
+```julia
+"""
+    sim(::typeof(siteinds), m::MPS) -> Vector{Index}
+    sim(::typeof(siteinds), w::MPO) -> Vector{Vector{Index}}
+
+Return cloned site indices with fresh IDs but matching dimensions, tags, and
+prime levels. Compatible with ITensorMPS's `sim(siteinds, mps)` pattern.
+"""
+sim(::typeof(siteinds), m::MPS) = [sim(idx) for idx in siteinds(m)]
+```
+
+For MPO, `TensorNetworks.siteinds(w.tt)` returns `Vector{Vector{Index}}`. We need to map `sim` over each inner vector:
+
+```julia
+sim(::typeof(siteinds), w::MPO) = [[sim(idx) for idx in group] for group in TensorNetworks.siteinds(w.tt)]
+```
+
+Add `sim` to the import from Tensor4all:
+```julia
+import ..Tensor4all: Index, Tensor, dim, inds, rank, scalar, prime, setprime, sim
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `julia --project=. test/itensorcompat/operator_overloads.jl`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ITensorCompat.jl test/itensorcompat/operator_overloads.jl
+git commit -m "feat: add sim(siteinds, ...) to ITensorCompat"
+```
+
+---
+
+### Task 5: `Base.adjoint(::Index)` — `'` operator on Index
+
+**Files:**
+- Modify: `src/Core/Index.jl`
+- Modify: `test/itensorcompat/operator_overloads.jl`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/itensorcompat/operator_overloads.jl`:
+
+```julia
+@testset "Index prime via ' operator" begin
+    idx = Index(4; tags=["x"], plev=0)
+    idx1 = idx'
+    @test Tensor4all.plev(idx1) == 1
+    @test Tensor4all.dim(idx1) == 4
+    @test Tensor4all.tags(idx1) == ["x"]
+    @test Tensor4all.id(idx1) == Tensor4all.id(idx)
+
+    idx2 = idx''
+    @test Tensor4all.plev(idx2) == 2
+
+    @test Tensor4all.plev(idx) == 0  # original unchanged
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `julia --project=. test/itensorcompat/operator_overloads.jl`
+Expected: FAIL — `MethodError: no method matching adjoint(::Index)`
+
+  - [ ] **Step 3: Write minimal implementation with docstring**
+
+Add at the end of Index.jl's Index operations section (after `setprime`, before `Base.:(==)` or wherever is appropriate) in `src/Core/Index.jl`:
+
+```julia
+"""
+    Base.adjoint(i::Index)
+
+Return `prime(i)`, enabling the `idx'` sugar syntax for creating a primed copy
+of an index. Compatible with ITensors.jl's `idx'` convention.
+"""
+Base.adjoint(i::Index) = prime(i)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `julia --project=. test/itensorcompat/operator_overloads.jl`
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `julia --project=. test/runtests.jl`
+Expected: all tests pass (including existing ones)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Core/Index.jl test/itensorcompat/operator_overloads.jl
+git commit -m "feat: add Base.adjoint(::Index) for prime sugar syntax"
+```

--- a/docs/test-reports/test-feature-20260423-171714.md
+++ b/docs/test-reports/test-feature-20260423-171714.md
@@ -1,0 +1,142 @@
+# Feature Test Report: Tensor4all.jl
+
+**Date:** 2026-04-23 17:17:14 JST
+**Project type:** Julia library
+**Features tested:** Core, TensorNetworks, SimpleTT, TensorCI, QuanticsGrids, QuanticsTCI, QuanticsTransform
+**Profile:** ephemeral
+**Use Case:** Downstream Julia users validate the public submodule APIs from README/docs and exercise each submodule through four realistic usage paths.
+**Expected Outcome:** Each public submodule can be loaded and used from documented public APIs; failures are actionable; documentation matches the implemented layer boundary.
+**Verdict:** pass
+**Critical Issues:** 0
+
+## Summary
+
+| Feature | Discoverable | Setup | Works | Expected Outcome Met | Doc Quality |
+|---------|-------------|-------|-------|----------------------|-------------|
+| Core | yes | yes | yes | yes | good |
+| TensorNetworks | yes | yes | yes | yes | mostly good |
+| SimpleTT | yes | yes | yes | yes | good |
+| TensorCI | partial | yes | yes | yes | README mismatch |
+| QuanticsGrids | partial | yes | yes | yes | wrapper docs are thin |
+| QuanticsTCI | partial | yes | yes | yes | wrapper docs are thin |
+| QuanticsTransform | partial | yes | yes | yes | one example and one API note are stale/incomplete |
+
+## Per-Feature Details
+
+### Core
+- **Role:** Julia developer using indexed tensor primitives directly.
+- **Use Case:** Build indices/tensors, manipulate metadata, contract tensors, factorize tensors, and check validation behavior.
+- **What they tried:** Four cases covering `Index`, `Tensor`, `contract`, `svd`, `qr`, scalar arithmetic, `Array(t, inds...)`, non-contiguous arrays, and dimension mismatch errors.
+- **Discoverability:** Good. `docs/src/getting_started.md` gives usable examples.
+- **Setup:** Worked with `julia --startup-file=no --project=.`.
+- **Functionality:** All 4/4 cases passed.
+- **Expected vs Actual Outcome:** Matched.
+- **Blocked steps:** None.
+- **Friction points:** None observed.
+- **Doc suggestions:** None required from this run.
+
+### TensorNetworks
+- **Role:** User building indexed MPS/MPO-like chains and applying operators.
+- **Use Case:** Build `TensorNetworks.TensorTrain`, query and replace site indices, materialize/evaluate dense data, and apply a `LinearOperator`.
+- **What they tried:** Four cases covering chain construction, `linkinds`, `siteinds`, tag queries, site replacement, diagonal helpers, `random_tt`, `to_dense`, `evaluate`, explicit `set_iospaces!`, and `apply`.
+- **Discoverability:** Good for chain construction and helpers; operator binding requires careful reading.
+- **Setup:** Worked.
+- **Functionality:** All 4/4 cases passed.
+- **Expected vs Actual Outcome:** Matched.
+- **Blocked steps:** None.
+- **Friction points:** `apply` correctly requires explicit binding, but one getting-started snippet omits that binding.
+- **Doc suggestions:** Add `TN.set_iospaces!(op, op.input_indices, op.output_indices)` to the `QuanticsTransform` apply example, or explain why custom true input/output spaces are needed.
+
+### SimpleTT
+- **Role:** User doing raw-array tensor train compression and MPO-MPO contraction.
+- **Use Case:** Create raw MPS/MPO tensor trains, compress with SVD, contract MPOs, and inspect validation errors.
+- **What they tried:** Four cases covering `TensorTrain{T,3}`, mutation, `compress!`, `contract(...; algorithm=:naive)`, `contract(...; algorithm=:zipup)`, unsupported algorithms, unsupported kwargs, and unsupported factorization methods.
+- **Discoverability:** Good.
+- **Setup:** Worked.
+- **Functionality:** All 4/4 cases passed.
+- **Expected vs Actual Outcome:** Matched.
+- **Blocked steps:** None.
+- **Friction points:** None observed.
+- **Doc suggestions:** None required from this run.
+
+### TensorCI
+- **Role:** User converting tensor cross interpolation output into `SimpleTT`.
+- **Use Case:** Run `crossinterpolate2`, evaluate the interpolation result, and convert to `SimpleTT.TensorTrain`.
+- **What they tried:** Four cases covering `crossinterpolate2`, `TensorCI2`, `SimpleTT.TensorTrain(tci)`, re-exported `evaluate` / `sitedims`, complex-valued interpolation, and one-site boundary validation.
+- **Discoverability:** Partial. API docs are clear, but README has stale wording.
+- **Setup:** Worked.
+- **Functionality:** All 4/4 cases passed.
+- **Expected vs Actual Outcome:** Matched the API docs: `crossinterpolate2` returns `TensorCI2`, and conversion to `SimpleTT.TensorTrain` is explicit.
+- **Blocked steps:** None.
+- **Friction points:** README says `TensorCI` returns `SimpleTT` and `TensorCI.crossinterpolate2` returns `SimpleTT.TensorTrain`, which contradicts the implemented public boundary.
+- **Doc suggestions:** Update README to say `TensorCI.crossinterpolate2 -> TensorCI2`, then `SimpleTT.TensorTrain(tci)` converts to raw-array TT.
+
+### QuanticsGrids
+- **Role:** User relying on the wrapper re-export for grid coordinate conversion.
+- **Use Case:** Build grids and convert between original coordinates, grid indices, and quantics indices.
+- **What they tried:** Four cases covering `DiscretizedGrid`, `InherentDiscreteGrid`, 1D roundtrips, 2D keyword conversion, and validation errors.
+- **Discoverability:** Partial. Tensor4all docs explain that this is a wrapper, but do not show usage examples.
+- **Setup:** Worked.
+- **Functionality:** All 4/4 cases passed.
+- **Expected vs Actual Outcome:** Matched upstream behavior.
+- **Blocked steps:** None.
+- **Friction points:** Users must know or find upstream `QuanticsGrids.jl` docs for constructor details.
+- **Doc suggestions:** Add one short wrapper example or link directly to upstream constructor docs.
+
+### QuanticsTCI
+- **Role:** User relying on the wrapper re-export for quantics cross interpolation.
+- **Use Case:** Interpolate simple functions/arrays, evaluate results, sum/integrate, inspect cache data, and build a Fourier MPO.
+- **What they tried:** Four cases covering 1D x-value interpolation, array overload, 2D size overload, `sum`, `integral`, `cachedata`, `quanticsfouriermpo`, and invalid grid-size validation.
+- **Discoverability:** Partial. Tensor4all docs identify the wrapper, but usage requires upstream knowledge.
+- **Setup:** Worked.
+- **Functionality:** All 4/4 cases passed.
+- **Expected vs Actual Outcome:** Matched upstream behavior.
+- **Blocked steps:** None.
+- **Friction points:** The wrapper surface is discoverable through `names`, but practical usage examples are not present in Tensor4all docs.
+- **Doc suggestions:** Add one minimal `quanticscrossinterpolate` example and upstream docs link.
+
+### QuanticsTransform
+- **Role:** User constructing quantics-specific operators and applying them through `TensorNetworks.apply`.
+- **Use Case:** Construct shift/flip/phase/cumsum/Fourier/affine/binary operators, apply a shift operator, and verify validation behavior.
+- **What they tried:** Four cases covering `shift_operator`, explicit I/O binding plus `apply`, scalar and multivar constructors, affine/binary constructors, and validation errors.
+- **Discoverability:** Partial. Constructor names are listed, but the first apply example is incomplete.
+- **Setup:** Worked.
+- **Functionality:** All 4/4 cases passed.
+- **Expected vs Actual Outcome:** Matched once explicit I/O spaces were bound.
+- **Blocked steps:** None.
+- **Friction points:** Calling `TN.apply(op, state)` directly on a newly constructed `QuanticsTransform` operator fails with an actionable binding error, but the getting-started example does not show the binding step.
+- **Doc suggestions:** Update `docs/src/getting_started.md` lines 185-190 to define `sites` from `op.input_indices` and bind I/O spaces before `apply`.
+
+## Expected vs Actual Outcome
+
+All 28 feature cases passed. The implemented public API matched the intended layer boundaries in source and API docs, except for documentation drift noted below.
+
+## Issues Found
+
+1. **Medium: README misstates the TensorCI boundary.** `README.md` says `TensorCI` returns `SimpleTT` and that `TensorCI.crossinterpolate2` returns `SimpleTT.TensorTrain`. The implementation and API docs return `TensorCI2`, with conversion handled by `SimpleTT.TensorTrain(tci)`.
+
+2. **Medium: Getting-started `QuanticsTransform` apply snippet is incomplete.** `docs/src/getting_started.md` shows `TN.apply(op, state)` after `shift_operator`, but does not bind true input/output spaces. A user following the snippet hits `op.true_input[1] is not bound. Call set_input_space!, set_output_space!, or set_iospaces! first.`
+
+3. **Low: API docs still describe `affine_pullback_operator` as deferred metadata-only.** `docs/src/api.md` says it is the remaining deferred placeholder, but a smoke check showed `affine_pullback_operator(3, 1, 1, 0, 1)` returns an MPO-backed operator with length 3.
+
+4. **Low: Wrapper modules are functionally usable but thinly documented.** `QuanticsGrids` and `QuanticsTCI` pass wrapper usage tests, but Tensor4all docs provide no minimal example beyond saying they are re-export wrappers.
+
+## Suggestions
+
+1. Update README TensorCI bullets to match the current architecture: `crossinterpolate2 -> TensorCI2`, then `SimpleTT.TensorTrain(tci)`.
+2. Update the `QuanticsTransform` getting-started snippet to include explicit `set_iospaces!` and a runnable state construction.
+3. Refresh the `affine_pullback_operator` note in `docs/src/api.md`.
+4. Add minimal wrapper examples for `QuanticsGrids` and `QuanticsTCI`, with links to upstream docs for full usage.
+
+## Raw Run Summary
+
+```text
+Core: 4/4 passed
+TensorNetworks: 4/4 passed
+SimpleTT: 4/4 passed
+TensorCI: 4/4 passed
+QuanticsGrids: 4/4 passed
+QuanticsTCI: 4/4 passed
+QuanticsTransform: 4/4 passed
+Total: 28/28 passed
+```

--- a/src/Core/Index.jl
+++ b/src/Core/Index.jl
@@ -158,6 +158,14 @@ function setprime(i::Index, n::Integer)
     return Index(dim(i); tags=tags(i), plev=Int(n), id=id(i), backend_handle=i.backend_handle)
 end
 
+"""
+    Base.adjoint(i::Index)
+
+Return `prime(i)`, enabling the `idx'` sugar syntax for creating a primed copy
+of an index. Compatible with ITensors.jl's `idx'` convention.
+"""
+Base.adjoint(i::Index) = prime(i)
+
 Base.:(==)(a::Index, b::Index) = (
     a.dim == b.dim &&
     a.id == b.id &&

--- a/src/ITensorCompat.jl
+++ b/src/ITensorCompat.jl
@@ -370,4 +370,15 @@ function replaceprime(w::MPO, pairs::Pair{Int,Int}...)
     return MPO(tt)
 end
 
+"""
+    sim(::typeof(siteinds), m::MPS) -> Vector{Index}
+    sim(::typeof(siteinds), w::MPO) -> Vector{Vector{Index}}
+
+Return cloned site indices with fresh IDs but matching dimensions, tags, and
+prime levels. Compatible with ITensorMPS's `sim(siteinds, mps)` pattern.
+"""
+sim(::typeof(siteinds), m::MPS) = [sim(idx) for idx in siteinds(m)]
+
+sim(::typeof(siteinds), w::MPO) = [[sim(idx) for idx in group] for group in TensorNetworks.siteinds(w.tt)]
+
 end

--- a/src/ITensorCompat.jl
+++ b/src/ITensorCompat.jl
@@ -13,6 +13,7 @@ export MPS, MPO
 export siteinds, linkinds, linkdims, rank
 export add, dag, dot, evaluate, inner, norm, replace_siteinds, replace_siteinds!, to_dense
 export fixinds, suminds, projectinds, scalar
+export maxlinkdim, data
 export orthogonalize!, truncate!
 
 const ITENSORS_CUTOFF_POLICY = SvdTruncationPolicy(
@@ -254,5 +255,26 @@ function MPO(
     stt = SimpleTT.TensorTrain{T,4}(_raw_mpo_blocks(blocks))
     return MPO(TensorNetworks.TensorTrain(stt, input_sites, output_sites))
 end
+
+"""
+    maxlinkdim(m::MPS) -> Int
+    maxlinkdim(w::MPO) -> Int
+
+Return the maximum bond dimension (link index dimension) of `m` or `w`.
+Equivalent to `rank(m)` / `rank(w)`. Compatible with `ITensorMPS.maxlinkdim`.
+"""
+maxlinkdim(m::MPS) = rank(m)
+maxlinkdim(w::MPO) = rank(w)
+
+"""
+    data(m::MPS) -> Vector{Tensor}
+    data(w::MPO) -> Vector{Tensor}
+    data(tt::TensorTrain) -> Vector{Tensor}
+
+Return the underlying tensor storage vector. Compatible with `ITensors.data`.
+"""
+data(m::MPS) = m.tt.data
+data(w::MPO) = w.tt.data
+data(tt::TensorTrain) = tt.data
 
 end

--- a/src/ITensorCompat.jl
+++ b/src/ITensorCompat.jl
@@ -1,6 +1,6 @@
 module ITensorCompat
 
-import ..Tensor4all: Index, Tensor, dim, inds, rank, scalar
+import ..Tensor4all: Index, Tensor, dim, rank, scalar
 import ..SimpleTT
 import ..TensorNetworks
 import ..TensorNetworks: TensorTrain
@@ -223,6 +223,18 @@ mutable struct MPO
             ))
         end
         return new(tt)
+    end
+    """
+        MPO(tensors::Vector{Tensor})
+
+    Construct an MPO from an existing vector of `Tensor4all.Tensor` objects.
+    Each tensor must have at least three indices (two site indices and at least
+    one link index). Compatible with the ITensorMPS `MPO(::Vector{ITensor})`
+    constructor.
+    """
+    function MPO(tensors::Vector{<:Tensor})
+        isempty(tensors) && throw(ArgumentError("MPO tensor vector must not be empty"))
+        return MPO(TensorTrain(tensors))
     end
 end
 

--- a/src/ITensorCompat.jl
+++ b/src/ITensorCompat.jl
@@ -1,6 +1,6 @@
 module ITensorCompat
 
-import ..Tensor4all: Index, Tensor, dim, rank, scalar
+import ..Tensor4all: Index, Tensor, dim, rank, inds, scalar, prime, setprime, sim, plev
 import ..SimpleTT
 import ..TensorNetworks
 import ..TensorNetworks: TensorTrain
@@ -14,6 +14,7 @@ export siteinds, linkinds, linkdims, rank
 export add, dag, dot, evaluate, inner, norm, replace_siteinds, replace_siteinds!, to_dense
 export fixinds, suminds, projectinds, scalar
 export maxlinkdim, data
+export prime, prime!, replaceprime
 export orthogonalize!, truncate!
 
 const ITENSORS_CUTOFF_POLICY = SvdTruncationPolicy(
@@ -288,5 +289,113 @@ Return the underlying tensor storage vector. Compatible with `ITensors.data`.
 data(m::MPS) = m.tt.data
 data(w::MPO) = w.tt.data
 data(tt::TensorTrain) = tt.data
+
+"""
+    prime(m::MPS, n::Integer=1) -> MPS
+    prime(w::MPO, n::Integer=1) -> MPO
+
+Return a copy of `m`/`w` with site index prime levels increased by `n`.
+Tensor data is shared (not copied). Compatible with `ITensorMPS.prime`.
+"""
+function prime(m::MPS, n::Integer=1)
+    sites = siteinds(m)
+    primed = prime.(sites, Ref(n))
+    tensors = map(m.tt.data) do t
+        t_inds = inds(t)
+        new_inds = map(t_inds) do idx
+            p = findfirst(==(idx), sites)
+            p === nothing ? idx : primed[p]
+        end
+        typeof(t)(t.data, new_inds, t.backend_handle, t.structured_storage)
+    end
+    return MPS(TensorTrain(tensors, m.tt.llim, m.tt.rlim))
+end
+
+function prime(w::MPO, n::Integer=1)
+    groups = TensorNetworks.siteinds(w.tt)
+    flat_old = reduce(vcat, groups)
+    flat_new = [prime(idx, n) for idx in flat_old]
+    tensors = map(w.tt.data) do t
+        t_inds = inds(t)
+        new_inds = map(t_inds) do idx
+            p = findfirst(==(idx), flat_old)
+            p === nothing ? idx : flat_new[p]
+        end
+        typeof(t)(t.data, new_inds, t.backend_handle, t.structured_storage)
+    end
+    return MPO(TensorTrain(tensors, w.tt.llim, w.tt.rlim))
+end
+
+"""
+    prime!(m::MPS, n::Integer=1) -> MPS
+    prime!(w::MPO, n::Integer=1) -> MPO
+
+In-place version of [`prime`](@ref). Modifies site index prime levels in place
+and returns the mutated MPS/MPO. Compatible with `ITensorMPS.prime!`.
+"""
+function prime!(m::MPS, n::Integer=1)
+    sites = siteinds(m)
+    primed = prime.(sites, Ref(n))
+    TensorNetworks.replace_siteinds!(m.tt, sites, primed)
+    return m
+end
+
+function prime!(w::MPO, n::Integer=1)
+    groups = TensorNetworks.siteinds(w.tt)
+    flat_old = reduce(vcat, groups)
+    flat_new = [prime(idx, n) for idx in flat_old]
+    TensorNetworks.replace_siteinds!(w.tt, flat_old, flat_new)
+    return w
+end
+
+"""
+    replaceprime(m::MPS, pairs::Pair{Int,Int}...) -> MPS
+    replaceprime(w::MPO, pairs::Pair{Int,Int}...) -> MPO
+
+Replace prime levels in site indices of `m`/`w` according to `pairs`.
+Each pair `old => new` replaces indices with `plev == old` to `plev == new`.
+Compatible with `ITensorMPS.replaceprime`.
+"""
+function replaceprime(m::MPS, pairs::Pair{Int,Int}...)
+    sites = siteinds(m)
+    mapped = map(sites) do idx
+        for (old, new) in pairs
+            plev(idx) == old && return setprime(idx, new)
+        end
+        return idx
+    end
+    tensors = map(m.tt.data) do t
+        t_inds = inds(t)
+        new_inds = map(t_inds) do idx
+            p = findfirst(==(idx), sites)
+            p === nothing ? idx : mapped[p]
+        end
+        typeof(t)(t.data, new_inds, t.backend_handle, t.structured_storage)
+    end
+    return MPS(TensorTrain(tensors, m.tt.llim, m.tt.rlim))
+end
+
+function replaceprime(w::MPO, pairs::Pair{Int,Int}...)
+    groups = TensorNetworks.siteinds(w.tt)
+    mapped = map(groups) do group
+        map(group) do idx
+            for (old, new) in pairs
+                plev(idx) == old && return setprime(idx, new)
+            end
+            return idx
+        end
+    end
+    flat_old = reduce(vcat, groups)
+    flat_new = reduce(vcat, mapped)
+    tensors = map(w.tt.data) do t
+        t_inds = inds(t)
+        new_inds = map(t_inds) do idx
+            p = findfirst(==(idx), flat_old)
+            p === nothing ? idx : flat_new[p]
+        end
+        typeof(t)(t.data, new_inds, t.backend_handle, t.structured_storage)
+    end
+    return MPO(TensorTrain(tensors, w.tt.llim, w.tt.rlim))
+end
 
 end

--- a/src/ITensorCompat.jl
+++ b/src/ITensorCompat.jl
@@ -6,7 +6,7 @@ import ..TensorNetworks
 import ..TensorNetworks: TensorTrain
 import ..TensorNetworks: add, dag, dot, evaluate, inner, linkdims, linkinds, norm, siteinds, to_dense
 import ..TensorNetworks: orthogonalize, truncate
-import ..TensorNetworks: replace_siteinds, replace_siteinds!
+import ..TensorNetworks: replace_siteinds, replace_siteinds!, replace_siteinds_shared
 import ..TensorNetworks: SvdTruncationPolicy
 
 export MPS, MPO
@@ -300,30 +300,16 @@ Tensor data is shared (not copied). Compatible with `ITensorMPS.prime`.
 function prime(m::MPS, n::Integer=1)
     sites = siteinds(m)
     primed = prime.(sites, Ref(n))
-    tensors = map(m.tt.data) do t
-        t_inds = inds(t)
-        new_inds = map(t_inds) do idx
-            p = findfirst(==(idx), sites)
-            p === nothing ? idx : primed[p]
-        end
-        typeof(t)(t.data, new_inds, t.backend_handle, t.structured_storage)
-    end
-    return MPS(TensorTrain(tensors, m.tt.llim, m.tt.rlim))
+    tt = replace_siteinds_shared(m.tt, sites, primed)
+    return MPS(tt)
 end
 
 function prime(w::MPO, n::Integer=1)
     groups = TensorNetworks.siteinds(w.tt)
     flat_old = reduce(vcat, groups)
     flat_new = [prime(idx, n) for idx in flat_old]
-    tensors = map(w.tt.data) do t
-        t_inds = inds(t)
-        new_inds = map(t_inds) do idx
-            p = findfirst(==(idx), flat_old)
-            p === nothing ? idx : flat_new[p]
-        end
-        typeof(t)(t.data, new_inds, t.backend_handle, t.structured_storage)
-    end
-    return MPO(TensorTrain(tensors, w.tt.llim, w.tt.rlim))
+    tt = replace_siteinds_shared(w.tt, flat_old, flat_new)
+    return MPO(tt)
 end
 
 """
@@ -364,15 +350,8 @@ function replaceprime(m::MPS, pairs::Pair{Int,Int}...)
         end
         return idx
     end
-    tensors = map(m.tt.data) do t
-        t_inds = inds(t)
-        new_inds = map(t_inds) do idx
-            p = findfirst(==(idx), sites)
-            p === nothing ? idx : mapped[p]
-        end
-        typeof(t)(t.data, new_inds, t.backend_handle, t.structured_storage)
-    end
-    return MPS(TensorTrain(tensors, m.tt.llim, m.tt.rlim))
+    tt = replace_siteinds_shared(m.tt, sites, mapped)
+    return MPS(tt)
 end
 
 function replaceprime(w::MPO, pairs::Pair{Int,Int}...)
@@ -387,15 +366,8 @@ function replaceprime(w::MPO, pairs::Pair{Int,Int}...)
     end
     flat_old = reduce(vcat, groups)
     flat_new = reduce(vcat, mapped)
-    tensors = map(w.tt.data) do t
-        t_inds = inds(t)
-        new_inds = map(t_inds) do idx
-            p = findfirst(==(idx), flat_old)
-            p === nothing ? idx : flat_new[p]
-        end
-        typeof(t)(t.data, new_inds, t.backend_handle, t.structured_storage)
-    end
-    return MPO(TensorTrain(tensors, w.tt.llim, w.tt.rlim))
+    tt = replace_siteinds_shared(w.tt, flat_old, flat_new)
+    return MPO(tt)
 end
 
 end

--- a/src/TensorNetworks.jl
+++ b/src/TensorNetworks.jl
@@ -24,7 +24,7 @@ export fixinds, suminds, projectinds
 export identity_link_tensor, insert_identity!
 export set_input_space!, set_output_space!, set_iospaces!, apply, linsolve
 export findsite, findsites, findallsiteinds_by_tag, findallsites_by_tag
-export replace_siteinds!, replace_siteinds, replace_siteinds_part!
+export replace_siteinds!, replace_siteinds, replace_siteinds_shared, replace_siteinds_part!
 export insert_operator_identity!, delete_operator_site!, delete_operator_sites!
 export permute_operator_sites!, replace_operator_input_indices!, replace_operator_output_indices!
 export rearrange_siteinds, makesitediagonal, extractdiagonal, matchsiteinds

--- a/src/TensorNetworks/site_helpers.jl
+++ b/src/TensorNetworks/site_helpers.jl
@@ -152,6 +152,24 @@ function _replace_tensor_indices!(tensor::Tensor, replacements::Dict{Tuple{UInt6
     return replaceinds!(tensor, old, new)
 end
 
+function _replace_tensor_indices_keep_data(tensor::Tensor, replacements::Dict{Tuple{UInt64, Int, Int}, Index})
+    current_indices = inds(tensor)
+    changed = false
+    new_indices = map(current_indices) do index
+        replacement = _replacement_for_index(index, replacements)
+        if replacement != index
+            changed = true
+        end
+        return replacement
+    end
+    if !changed
+        return tensor
+    end
+    return Tensor{eltype(tensor.data),ndims(tensor.data)}(
+        tensor.data, new_indices, tensor.backend_handle, tensor.structured_storage
+    )
+end
+
 _copy_tensor(tensor::Tensor) = Tensor(tensor.data, inds(tensor); backend_handle=tensor.backend_handle)
 _copy_train(tt::TensorTrain) = TensorTrain([_copy_tensor(tensor) for tensor in tt.data], tt.llim, tt.rlim)
 
@@ -242,6 +260,27 @@ function replace_siteinds(
 )
     copied = _copy_train(tt)
     return replace_siteinds!(copied, oldsites, newsites)
+end
+
+"""
+    replace_siteinds_shared(tt, oldsites, newsites)
+
+Return a new `TensorTrain` with each site-like index in `oldsites` replaced by
+the corresponding index in `newsites`. Unlike [`replace_siteinds`](@ref), tensor
+data arrays are shared (not copied). Compatible with the ITensorMPS convention
+where `prime(mps)` creates new index metadata but shares tensor storage.
+
+See also [`replace_siteinds`](@ref), [`replace_siteinds!`](@ref).
+"""
+function replace_siteinds_shared(
+    tt::TensorTrain,
+    oldsites::AbstractVector{<:Index},
+    newsites::AbstractVector{<:Index},
+)
+    replacements = _replacement_mapping(oldsites, newsites)
+    _ensure_replacement_targets_exist(tt, oldsites)
+    tensors = [_replace_tensor_indices_keep_data(t, replacements) for t in tt.data]
+    return TensorTrain(tensors, tt.llim, tt.rlim)
 end
 
 """

--- a/test/itensorcompat/operator_overloads.jl
+++ b/test/itensorcompat/operator_overloads.jl
@@ -48,3 +48,21 @@ end
     @test dtt isa Vector{Tensor4all.Tensor}
     @test length(dtt) == 1
 end
+
+@testset "MPO from Tensor vector" begin
+    i1 = Index(2; tags=["i1"]); o1 = Index(2; tags=["o1"])
+    i2 = Index(2; tags=["i2"]); o2 = Index(2; tags=["o2"])
+    l1 = Index(3; tags=["Link", "l=1"])
+    t1 = Tensor(reshape(collect(1.0:12.0), 2, 2, 3), [i1, o1, l1])
+    t2 = Tensor(reshape(collect(1.0:12.0), 3, 2, 2), [l1, i2, o2])
+    w = IC.MPO([t1, t2])
+    @test length(w) == 2
+    @test length(IC.siteinds(w)) == 2
+    @test IC.siteinds(w)[1] == [i1, o1]
+    @test IC.siteinds(w)[2] == [i2, o2]
+    @test IC.data(w)[1] === t1
+
+    # error case: tensor with wrong number of site indices
+    t_bad = Tensor(reshape(collect(1.0:6.0), 3, 2), [l1, i2])
+    @test_throws ArgumentError IC.MPO([t1, t_bad])
+end

--- a/test/itensorcompat/operator_overloads.jl
+++ b/test/itensorcompat/operator_overloads.jl
@@ -155,3 +155,17 @@ end
     @test all(length(g) == 2 for g in new_sites)
     @test id.(vcat(new_sites...)) != id.(vcat(i1, o1, i2, o2))
 end
+
+@testset "Index prime via ' operator" begin
+    idx = Index(4; tags=["x"], plev=0)
+    idx1 = idx'
+    @test Tensor4all.plev(idx1) == 1
+    @test Tensor4all.dim(idx1) == 4
+    @test Tensor4all.tags(idx1) == ["x"]
+    @test Tensor4all.id(idx1) == Tensor4all.id(idx)
+
+    idx2 = idx''
+    @test Tensor4all.plev(idx2) == 2
+
+    @test Tensor4all.plev(idx) == 0  # original unchanged
+end

--- a/test/itensorcompat/operator_overloads.jl
+++ b/test/itensorcompat/operator_overloads.jl
@@ -66,3 +66,62 @@ end
     t_bad = Tensor(reshape(collect(1.0:6.0), 3, 2), [l1, i2])
     @test_throws ArgumentError IC.MPO([t1, t_bad])
 end
+
+@testset "prime/prime! on MPS" begin
+    sites = [Index(2; tags=["s$n"]) for n in 1:2]
+    blocks = [
+        reshape([1.0, 0.0, 0.0, 1.0], 1, 2, 2),
+        reshape([2.0, 0.0, 0.0, -1.0], 2, 2, 1),
+    ]
+    m = IC.MPS(blocks, sites)
+
+    mp = IC.prime(m)
+    @test IC.siteinds(mp)[1].plev == 1
+    @test IC.siteinds(m)[1].plev == 0  # original unchanged
+    @test mp[1].data === m[1].data     # tensor data shared
+
+    IC.prime!(m)
+    @test IC.siteinds(m)[1].plev == 1
+
+    mp2 = IC.prime(m, 2)
+    @test IC.siteinds(mp2)[1].plev == 3
+end
+
+@testset "prime/prime! on MPO" begin
+    i1 = Index(2; tags=["i1"]); o1 = Index(2; tags=["o1"])
+    i2 = Index(2; tags=["i2"]); o2 = Index(2; tags=["o2"])
+    l1 = Index(3; tags=["Link", "l=1"])
+    t1 = Tensor(reshape(collect(1.0:12.0), 2, 2, 3), [i1, o1, l1])
+    t2 = Tensor(reshape(collect(1.0:12.0), 3, 2, 2), [l1, i2, o2])
+    w = IC.MPO([t1, t2])
+
+    wp = IC.prime(w)
+    @test all(idx.plev == 1 for idx in Iterators.flatten(IC.siteinds(wp)))
+    @test all(idx.plev == 0 for idx in Iterators.flatten(IC.siteinds(w)))
+
+    IC.prime!(w)
+    @test all(idx.plev == 1 for idx in Iterators.flatten(IC.siteinds(w)))
+end
+
+@testset "replaceprime on MPS" begin
+    sites = [Index(2; tags=["s$n"], plev=2) for n in 1:2]
+    blocks = [
+        reshape([1.0, 0.0, 0.0, 1.0], 1, 2, 2),
+        reshape([2.0, 0.0, 0.0, -1.0], 2, 2, 1),
+    ]
+    m = IC.MPS(blocks, sites)
+    mr = IC.replaceprime(m, 2 => 0)
+    @test IC.siteinds(mr)[1].plev == 0
+    @test IC.siteinds(m)[1].plev == 2   # original unchanged
+end
+
+@testset "replaceprime on MPO" begin
+    i1 = Index(2; tags=["i1"], plev=1); o1 = Index(2; tags=["o1"], plev=1)
+    i2 = Index(2; tags=["i2"], plev=1); o2 = Index(2; tags=["o2"], plev=1)
+    l1 = Index(3; tags=["Link", "l=1"])
+    t1 = Tensor(reshape(collect(1.0:12.0), 2, 2, 3), [i1, o1, l1])
+    t2 = Tensor(reshape(collect(1.0:12.0), 3, 2, 2), [l1, i2, o2])
+    w = IC.MPO([t1, t2])
+    wr = IC.replaceprime(w, 1 => 0)
+    @test all(idx.plev == 0 for idx in Iterators.flatten(IC.siteinds(wr)))
+end

--- a/test/itensorcompat/operator_overloads.jl
+++ b/test/itensorcompat/operator_overloads.jl
@@ -1,0 +1,50 @@
+using Test
+using Tensor4all
+
+const IC = Tensor4all.ITensorCompat
+const TN = Tensor4all.TensorNetworks
+
+@testset "maxlinkdim" begin
+    sites = [Index(2; tags=["s$n"]) for n in 1:3]
+    blocks = [
+        reshape(collect(1.0:8.0), 1, 2, 4),
+        reshape(collect(1.0:24.0), 4, 2, 3),
+        reshape(collect(1.0:6.0), 3, 2, 1),
+    ]
+    m = IC.MPS(blocks, sites)
+    @test IC.maxlinkdim(m) == 4
+
+    blocks_mpo = [
+        reshape(collect(1.0:12.0), 1, 2, 2, 3),
+        reshape(collect(1.0:12.0), 3, 2, 2, 1),
+    ]
+    input = [Index(2; tags=["in$n"]) for n in 1:2]
+    output = [Index(2; tags=["out$n"]) for n in 1:2]
+    w = IC.MPO(blocks_mpo, input, output)
+    @test IC.maxlinkdim(w) == 3
+end
+
+@testset "data accessor" begin
+    sites = [Index(2; tags=["s$n"]) for n in 1:2]
+    blocks = [
+        reshape([1.0, 0.0, 0.0, 1.0], 1, 2, 2),
+        reshape([2.0, 0.0, 0.0, -1.0], 2, 2, 1),
+    ]
+    m = IC.MPS(blocks, sites)
+    d = IC.data(m)
+    @test d isa Vector{Tensor4all.Tensor}
+    @test length(d) == 2
+
+    input = [Index(2; tags=["in$n"]) for n in 1:1]
+    output = [Index(2; tags=["out$n"]) for n in 1:1]
+    blocks_mpo = [reshape([1.0, 0.0, 0.0, -1.0], 1, 2, 2, 1)]
+    w = IC.MPO(blocks_mpo, input, output)
+    dw = IC.data(w)
+    @test dw isa Vector{Tensor4all.Tensor}
+    @test length(dw) == 1
+
+    tt = TN.TensorTrain([Tensor(1.0)])
+    dtt = IC.data(tt)
+    @test dtt isa Vector{Tensor4all.Tensor}
+    @test length(dtt) == 1
+end

--- a/test/itensorcompat/operator_overloads.jl
+++ b/test/itensorcompat/operator_overloads.jl
@@ -125,3 +125,33 @@ end
     wr = IC.replaceprime(w, 1 => 0)
     @test all(idx.plev == 0 for idx in Iterators.flatten(IC.siteinds(wr)))
 end
+
+@testset "sim(siteinds, ...) on MPS" begin
+    sites = [Index(2; tags=["s$n"], plev=n) for n in 1:2]
+    blocks = [
+        reshape([1.0, 0.0, 0.0, 1.0], 1, 2, 2),
+        reshape([2.0, 0.0, 0.0, -1.0], 2, 2, 1),
+    ]
+    m = IC.MPS(blocks, sites)
+    new_sites = IC.sim(IC.siteinds, m)
+    @test new_sites isa Vector{Tensor4all.Index}
+    @test length(new_sites) == 2
+    @test dim.(new_sites) == dim.(sites)
+    @test Tensor4all.tags.(new_sites) == Tensor4all.tags.(sites)
+    @test plev.(new_sites) == plev.(sites)
+    @test id.(new_sites) != id.(sites)
+end
+
+@testset "sim(siteinds, ...) on MPO" begin
+    i1 = Index(2; tags=["i1"]); o1 = Index(2; tags=["o1"])
+    i2 = Index(2; tags=["i2"]); o2 = Index(2; tags=["o2"])
+    l1 = Index(3; tags=["Link", "l=1"])
+    t1 = Tensor(reshape(collect(1.0:12.0), 2, 2, 3), [i1, o1, l1])
+    t2 = Tensor(reshape(collect(1.0:12.0), 3, 2, 2), [l1, i2, o2])
+    w = IC.MPO([t1, t2])
+    new_sites = IC.sim(IC.siteinds, w)
+    @test new_sites isa Vector{Vector{Tensor4all.Index}}
+    @test length(new_sites) == 2
+    @test all(length(g) == 2 for g in new_sites)
+    @test id.(vcat(new_sites...)) != id.(vcat(i1, o1, i2, o2))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,6 +38,7 @@ include("tensorci/surface.jl")
 include("tensorci/crossinterpolate2.jl")
 include("itensorcompat/raw_blocks.jl")
 include("itensorcompat/bubbleteaci_workflow.jl")
+include("itensorcompat/operator_overloads.jl")
 include("quanticsgrids/surface.jl")
 include("quanticstci/surface.jl")
 if get(ENV, "T4A_SKIP_HDF5_TESTS", "0") != "1" && Base.find_package("HDF5") !== nothing

--- a/test/tensornetworks/skeleton_surface.jl
+++ b/test/tensornetworks/skeleton_surface.jl
@@ -12,6 +12,7 @@ using Tensor4all
         Symbol("replace_siteinds!"),
         :replace_siteinds,
         Symbol("replace_siteinds_part!"),
+        :replace_siteinds_shared,
         :rearrange_siteinds,
         :makesitediagonal,
         :extractdiagonal,


### PR DESCRIPTION
## Summary

Extend `ITensorCompat` module with MPS/MPO operations needed for migrating
`BubbleTeaCI.jl` and `QuanticsNEGF.jl` away from ITensors.jl/ITensorMPS.jl.

### New API Surface

**MPS/MPO constructors and operations:**
- `MPO(tensors::Vector{Tensor})` — construct from pre-built Tensor vector
- `prime(m::MPS)` / `prime(w::MPO)` — non-mutating, data shared
- `prime!(m::MPS)` / `prime!(w::MPO)` — in-place
- `replaceprime(m::MPS, pairs...)` / `replaceprime(w::MPO, pairs...)`
- `sim(::typeof(siteinds), m::MPS)` / `sim(::typeof(siteinds), w::MPO)`

**Index sugar:**
- `Base.adjoint(::Index)` — `idx'` as sugar for `prime(idx)`

**Accessors:**
- `maxlinkdim(m::MPS)` / `maxlinkdim(w::MPO)`
- `data(m::MPS)` / `data(w::MPO)` / `data(tt::TensorTrain)`

**TensorNetworks addition:**
- `replace_siteinds_shared(tt, oldsites, newsites)` — non-copying index
  replacement (tensor data shared, only index metadata updated)

All functions have docstrings matching Tensor4all style.