### PR TITLE
[codex] Validate Index tag backend limits

### DIFF
--- a/src/Core/Index.jl
+++ b/src/Core/Index.jl
@@ -1,4 +1,6 @@
 const _next_index_id = Ref{UInt64}(0)
+const _MAX_INDEX_TAGS = 4
+const _MAX_INDEX_TAG_LENGTH = 16
 
 next_index_id() = (_next_index_id[] += UInt64(1))
 
@@ -22,6 +24,19 @@ function _normalize_tags(tags::AbstractVector{<:AbstractString})
     return _normalize_tags(join(String.(tags), ","))
 end
 
+function _validate_index_tags(tags::AbstractVector{<:AbstractString})
+    length(tags) <= _MAX_INDEX_TAGS || throw(ArgumentError(
+        "Index supports at most $_MAX_INDEX_TAGS tags for the tensor4all-rs backend, got $(length(tags)): $(collect(tags))",
+    ))
+    for tag in tags
+        tag_length = length(tag)
+        tag_length <= _MAX_INDEX_TAG_LENGTH || throw(ArgumentError(
+            "Index tag length must be at most $_MAX_INDEX_TAG_LENGTH characters for the tensor4all-rs backend, got $tag_length for \"$tag\"",
+        ))
+    end
+    return nothing
+end
+
 """
     Index(dim; tags=String[], plev=0, id=next_index_id(), backend_handle=nothing)
     Index(dim, tags; plev=0, id=next_index_id(), backend_handle=nothing)
@@ -30,7 +45,9 @@ Create a Julia-side review skeleton for an indexed tensor leg.
 
 The metadata behavior is implemented during the skeleton phase, while the
 optional backend handle keeps the public shape aligned with the eventual
-backend-facing design.
+backend-facing design. Tags are normalized, deduplicated, sorted, and validated
+against the current tensor4all-rs backend limit of at most 4 tags, each at most
+16 characters.
 
 # Examples
 ```jldoctest
@@ -63,7 +80,10 @@ function Index(
     return Index(
         Int(dim),
         UInt64(id),
-        _normalize_tags(tags),
+        let normalized_tags = _normalize_tags(tags)
+            _validate_index_tags(normalized_tags)
+            normalized_tags
+        end,
         Int(plev),
         backend_handle,
     )

--- a/src/TensorNetworks/operator_canonical.jl
+++ b/src/TensorNetworks/operator_canonical.jl
@@ -38,7 +38,7 @@ function _shared_index_with_neighbor(
 end
 
 function _operator_boundary_link(position::Int, side::Symbol)
-    return Index(1; tags=["Link", "operator-boundary=$position", "side=$(String(side))"])
+    return Index(1; tags=["Link", "op-bnd=$position", "side=$(String(side))"])
 end
 
 function _operator_link_indices(tt::TensorTrain, position::Int, input_index::Index, output_index::Index)

--- a/test/core/index.jl
+++ b/test/core/index.jl
@@ -58,6 +58,20 @@ end
     @test Tensor4all.tags(whitespace_corners) == ["a\tb", "c\u00a0d", "e\u3000f"]
 end
 
+@testset "Index tag backend constraints" begin
+    sixteen = "abcdefghijklmnop"
+    @test length(sixteen) == 16
+    @test Tensor4all.tags(Tensor4all.Index(2; tags=[sixteen])) == [sixteen]
+    @test Tensor4all.tags(Tensor4all.Index(2, "a,b,c,d")) == ["a", "b", "c", "d"]
+
+    long_tag = "abcdefghijklmnopq"
+    @test length(long_tag) == 17
+    @test_throws ArgumentError Tensor4all.Index(2; tags=[long_tag])
+    @test_throws ArgumentError Tensor4all.Index(2, long_tag)
+    @test_throws ArgumentError Tensor4all.Index(2; tags=["a", "b", "c", "d", "e"])
+    @test_throws ArgumentError Tensor4all.Index(2, "a,b,c,d,e")
+end
+
 @testset "Index replacement compatibility" begin
     i = Tensor4all.Index(2; tags=["i"])
     j = Tensor4all.Index(3; tags=["j"])

--- a/test/tensornetworks/operator_mutations.jl
+++ b/test/tensornetworks/operator_mutations.jl
@@ -172,7 +172,7 @@ end
             plev=plev(old_input),
             id=id(old_input),
         )
-        new_input = Index(dim(old_input); tags=["identity-renamed-in"])
+        new_input = Index(dim(old_input); tags=["id-ren-in"])
 
         @test_throws ArgumentError TN_OPMUT.replace_operator_input_indices!(op, [metadata_copy], [new_input])
     end


### PR DESCRIPTION
## Summary

- validate normalized `Index` tags at construction time against the current tensor4all-rs `TagSet<4,16>` backend limits
- reject more than 4 tags and tags longer than 16 characters with local `ArgumentError`s
- shorten internal operator boundary tags so generated indices also satisfy the same backend invariant
- add boundary and rejection coverage for string and vector tag constructors

## Validation

- `env JULIA_NUM_THREADS=1 JULIA_NUM_GC_THREADS=1 OPENBLAS_NUM_THREADS=1 BLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 RAYON_NUM_THREADS=1 TENSOR4ALL_NUM_THREADS=1 julia --startup-file=no --project=. test/core/index.jl`
- `env JULIA_NUM_THREADS=1 JULIA_NUM_GC_THREADS=1 OPENBLAS_NUM_THREADS=1 BLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 RAYON_NUM_THREADS=1 TENSOR4ALL_NUM_THREADS=1 julia --startup-file=no --project=. test/tensornetworks/operator_mutations.jl`
- `env JULIA_NUM_THREADS=1 JULIA_NUM_GC_THREADS=1 OPENBLAS_NUM_THREADS=1 BLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 RAYON_NUM_THREADS=1 TENSOR4ALL_NUM_THREADS=1 T4A_SKIP_HDF5_TESTS=1 julia --startup-file=no --project=. test/runtests.jl`
- `env JULIA_NUM_THREADS=1 JULIA_NUM_GC_THREADS=1 OPENBLAS_NUM_THREADS=1 BLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 RAYON_NUM_THREADS=1 TENSOR4ALL_NUM_THREADS=1 julia --startup-file=no --project=docs docs/make.jl`
- `env JULIA_NUM_THREADS=1 JULIA_NUM_GC_THREADS=1 OPENBLAS_NUM_THREADS=1 BLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 RAYON_NUM_THREADS=1 TENSOR4ALL_NUM_THREADS=1 julia --startup-file=no --project=. scripts/check_autodocs_coverage.jl`

Closes #88.
