### PR TITLE
[codex] Redesign Tensor storage around backend handles

### DIFF
--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -15,3 +15,22 @@
 - Regression tests for index matching code should include two indices with the
   same `id` but different `plev`, and two indices with the same `id` and `plev`
   but different `tags`.
+
+## FFI Handle Ownership Discipline
+
+- Any Julia object that owns a Rust/C handle must make ownership explicit in
+  its constructor or wrapper type.
+- Do not rely on Julia's default `deepcopy` for objects that contain owned raw
+  pointers. Define `Base.deepcopy_internal` to either clone/rebuild the
+  backend resource or throw an actionable error.
+- Public copy operations for handle-backed public objects must create an
+  independently owned backend resource. They must not share an owned raw
+  pointer with the source object.
+- Direct copying of low-level handle wrappers should be disallowed unless the
+  wrapper is explicitly non-owning or reference-counted.
+- When transferring a newly returned C handle into a Julia finalizer-backed
+  object, clear the local raw pointer variable before the surrounding `finally`
+  block releases temporary handles.
+- Regression tests for handle-backed public objects should check that
+  `copy`/`deepcopy` preserve data and metadata while producing distinct backend
+  pointers.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -15,6 +15,8 @@
 - `Tensor4all.inds`, `Tensor4all.rank`, `Tensor4all.dims`,
   `Tensor4all.swapinds`
 - `Tensor4all.scalar`, `Tensor4all.onehot`
+- `Tensor4all.copy_data` — explicitly materialize a fresh dense copy of a
+  `Tensor`, optionally in a requested `Index` order
 - `Tensor4all.fixinds`, `Tensor4all.suminds`, `Tensor4all.projectinds`
 - `Tensor4all.delta`, `Tensor4all.isdiag`,
   `Tensor4all.structured_storage_info`, `Tensor4all.structured_payload`
@@ -24,6 +26,10 @@
   `t4a_tensor_contract` C API
 - `Tensor4all.svd`, `Tensor4all.qr` — backend tensor factorizations via the
   C API
+
+`Tensor` owns a backend tensor handle plus Julia-side `Index` metadata. It does
+not expose `.data` or cached `structured_storage` fields; dense materialization
+is always an explicit copy through `copy_data` or `Array`.
 
 ```@docs
 Tensor4all

--- a/ext/Tensor4allHDF5Ext.jl
+++ b/ext/Tensor4allHDF5Ext.jl
@@ -53,9 +53,10 @@ function _write_itensor(parent::Union{HDF5.File,HDF5.Group}, name::AbstractStrin
     attributes(g)["version"] = _VERSION
     _write_indexset(g, "inds", Tensor4all.inds(t))
     storage = create_group(g, "storage")
-    attributes(storage)["type"] = _dense_typestr(eltype(t.data))
+    data = Tensor4all.copy_data(t)
+    attributes(storage)["type"] = _dense_typestr(eltype(data))
     attributes(storage)["version"] = _VERSION
-    write(storage, "data", vec(t.data))
+    write(storage, "data", vec(data))
     return g
 end
 

--- a/src/Core/IndexOps.jl
+++ b/src/Core/IndexOps.jl
@@ -20,10 +20,9 @@ end
 
 function _copy_tensor_without_index_op(t::Tensor)
     return Tensor(
-        t.data,
+        copy_data(t),
         inds(t);
-        backend_handle=t.backend_handle,
-        structured_storage=_copy_structured_storage(t.structured_storage),
+        structured_storage=_structured_storage_from_tensor(t),
     )
 end
 
@@ -53,7 +52,7 @@ function fixinds(t::Tensor, replacements::Pair{Index,<:Integer}...)
     end
 
     result_inds = Index[tensor_indices[n] for n in eachindex(tensor_indices) if !fixed[n]]
-    return _tensor_from_indexed_data(t.data[selectors...], result_inds)
+    return _tensor_from_indexed_data(copy_data(t)[selectors...], result_inds)
 end
 
 """
@@ -70,7 +69,7 @@ function suminds(t::Tensor, indices::Index...)
     axes = [_index_position(tensor_indices, index, "suminds") for index in requested]
     result_inds = Index[tensor_indices[n] for n in eachindex(tensor_indices) if !(n in axes)]
 
-    summed = sum(t.data; dims=Tuple(sort(axes)))
+    summed = sum(copy_data(t); dims=Tuple(sort(axes)))
     dropped = dropdims(summed; dims=Tuple(sort(axes)))
     return _tensor_from_indexed_data(dropped, result_inds)
 end
@@ -109,5 +108,5 @@ function projectinds(
         seen[position] = true
     end
 
-    return Tensor(copy(t.data[selectors...]), result_inds)
+    return Tensor(copy(copy_data(t)[selectors...]), result_inds)
 end

--- a/src/Core/Tensor.jl
+++ b/src/Core/Tensor.jl
@@ -38,17 +38,90 @@ _backend_handle_ptr(handle::TensorHandle) = handle.ptr
 const _CORE_T4A_SUCCESS = Cint(0)
 const _CORE_T4A_SCALAR_KIND_F64 = Cint(0)
 const _CORE_T4A_SCALAR_KIND_C64 = Cint(1)
+const _CORE_T4A_STORAGE_KIND_DENSE = Cint(0)
+const _CORE_T4A_STORAGE_KIND_DIAGONAL = Cint(1)
+const _CORE_T4A_STORAGE_KIND_STRUCTURED = Cint(2)
+
+_core_t4a(symbol::Symbol) = Libdl.dlsym(require_backend(), symbol)
+
+function _core_last_backend_error_message()
+    out_len = Ref{Csize_t}(0)
+    status = ccall(
+        _core_t4a(:t4a_last_error_message),
+        Cint,
+        (Ptr{UInt8}, Csize_t, Ref{Csize_t}),
+        C_NULL,
+        0,
+        out_len,
+    )
+    status == _CORE_T4A_SUCCESS || return "backend error (status $status)"
+    out_len[] == 0 && return "backend error"
+
+    buffer = Vector{UInt8}(undef, Int(out_len[]))
+    status = ccall(
+        _core_t4a(:t4a_last_error_message),
+        Cint,
+        (Ptr{UInt8}, Csize_t, Ref{Csize_t}),
+        buffer,
+        length(buffer),
+        out_len,
+    )
+    status == _CORE_T4A_SUCCESS || return "backend error (status $status)"
+    nul = findfirst(==(0x00), buffer)
+    return nul === nothing ? String(buffer) : String(buffer[1:(nul - 1)])
+end
+
+function _core_check_backend_status(status::Integer, context::AbstractString)
+    status == _CORE_T4A_SUCCESS && return nothing
+    message = _core_last_backend_error_message()
+    lowered = lowercase(message)
+    if occursin("dimension", lowered) || occursin("mismatch", lowered)
+        throw(DimensionMismatch("$context failed: $message"))
+    end
+    throw(ArgumentError("$context failed: $message"))
+end
+
+function _core_release_index_handle(ptr::Ptr{Cvoid})
+    ptr == C_NULL && return nothing
+    ccall(_core_t4a(:t4a_index_release), Cvoid, (Ptr{Cvoid},), ptr)
+    return nothing
+end
+
+function _core_new_index_handle(index::Index)
+    out = Ref{Ptr{Cvoid}}(C_NULL)
+    status = ccall(
+        _core_t4a(:t4a_index_new_with_id),
+        Cint,
+        (Csize_t, UInt64, Cstring, Int64, Ref{Ptr{Cvoid}}),
+        dim(index),
+        id(index),
+        join(tags(index), ","),
+        plev(index),
+        out,
+    )
+    _core_check_backend_status(status, "creating backend index $index")
+    return out[]
+end
+
+function _core_interleaved_complex_data(data)
+    raw = Vector{Float64}(undef, 2 * length(data))
+    for (n, value) in enumerate(data)
+        z = ComplexF64(value)
+        raw[2n-1] = real(z)
+        raw[2n] = imag(z)
+    end
+    return raw
+end
 
 """
     Tensor(data, inds; backend_handle=nothing)
 
-Create a tensor from Julia-owned dense array data and index metadata.
+Create a tensor from dense array data and index metadata.
 
-This constructor validates metadata and shape consistency. Tensors keep a dense
-Julia snapshot when constructed from arrays. Backend operations may return
-handle-backed tensors that materialize dense Julia data lazily for indexing and
-`Array` extraction; selected constructors may also attach compact storage
-metadata used by backend calls.
+This constructor validates metadata and shape consistency, then immediately
+creates a backend tensor handle. `Tensor` stores the handle and Julia-side
+index metadata only; use [`copy_data`](@ref) or `Array(t, inds...)` to
+explicitly materialize a fresh dense Julia copy.
 
 # Examples
 ```jldoctest
@@ -65,10 +138,8 @@ julia> (rank(t), dims(t))
 ```
 """
 mutable struct Tensor{T,N}
-    data::Union{Nothing,Array{T,N}}
+    handle::TensorHandle
     inds::Vector{Index}
-    backend_handle::Union{Nothing,Ptr{Cvoid},TensorHandle}
-    structured_storage::Union{Nothing,StructuredTensorStorage{T}}
 end
 
 """
@@ -93,7 +164,156 @@ function Tensor(
         "Tensor dimensions $expected_dims do not match data size $(size(data))",
     ))
     _validate_structured_storage(structured_storage, expected_dims)
-    return Tensor{T,N}(copy(data), collect(inds), backend_handle, structured_storage)
+    indices = collect(inds)
+    if backend_handle === nothing
+        handle = TensorHandle(_core_new_tensor_handle_from_array(data, indices, structured_storage))
+        return Tensor{T,N}(handle, indices)
+    end
+    handle = backend_handle isa TensorHandle ? backend_handle : TensorHandle(backend_handle; owned=false)
+    return Tensor{T,N}(handle, indices)
+end
+
+function _core_new_dense_tensor_handle_from_array(data::Array, indices::Vector{Index}, scalar_kind::Symbol, index_handles)
+    out = Ref{Ptr{Cvoid}}(C_NULL)
+    if scalar_kind === :f64
+        dense = convert(Array{Float64,ndims(data)}, data)
+        status = ccall(
+            _core_t4a(:t4a_tensor_new_dense_f64),
+            Cint,
+            (Csize_t, Ptr{Ptr{Cvoid}}, Ptr{Float64}, Csize_t, Ref{Ptr{Cvoid}}),
+            length(indices),
+            index_handles,
+            dense,
+            length(dense),
+            out,
+        )
+        _core_check_backend_status(status, "creating dense backend tensor")
+        return out[]
+    elseif scalar_kind === :c64
+        dense = _core_interleaved_complex_data(data)
+        status = ccall(
+            _core_t4a(:t4a_tensor_new_dense_c64),
+            Cint,
+            (Csize_t, Ptr{Ptr{Cvoid}}, Ptr{Float64}, Csize_t, Ref{Ptr{Cvoid}}),
+            length(indices),
+            index_handles,
+            dense,
+            length(data),
+            out,
+        )
+        _core_check_backend_status(status, "creating dense backend tensor")
+        return out[]
+    end
+    throw(ArgumentError("Tensor supports only real or complex dense arrays for backend construction, got eltype $(eltype(data))"))
+end
+
+function _core_new_structured_tensor_handle_from_storage(
+    storage::StructuredTensorStorage,
+    tensor_rank::Int,
+    scalar_kind::Symbol,
+    index_handles,
+)
+    out = Ref{Ptr{Cvoid}}(C_NULL)
+    if storage.kind === :diagonal
+        if scalar_kind === :f64
+            payload = Float64.(storage.payload)
+            status = ccall(
+                _core_t4a(:t4a_tensor_new_diag_f64),
+                Cint,
+                (Csize_t, Ptr{Ptr{Cvoid}}, Ptr{Float64}, Csize_t, Ref{Ptr{Cvoid}}),
+                tensor_rank,
+                index_handles,
+                payload,
+                length(payload),
+                out,
+            )
+        elseif scalar_kind === :c64
+            payload = _core_interleaved_complex_data(storage.payload)
+            status = ccall(
+                _core_t4a(:t4a_tensor_new_diag_c64),
+                Cint,
+                (Csize_t, Ptr{Ptr{Cvoid}}, Ptr{Float64}, Csize_t, Ref{Ptr{Cvoid}}),
+                tensor_rank,
+                index_handles,
+                payload,
+                length(storage.payload),
+                out,
+            )
+        else
+            throw(ArgumentError("Unknown scalar kind $scalar_kind"))
+        end
+        _core_check_backend_status(status, "creating diagonal backend tensor")
+        return out[]
+    elseif storage.kind === :structured
+        payload_dims = Csize_t.(storage.payload_dims)
+        payload_strides = Cptrdiff_t.(storage.payload_strides)
+        axis_classes = Csize_t.(storage.axis_classes .- 1)
+        if scalar_kind === :f64
+            payload = Float64.(storage.payload)
+            status = ccall(
+                _core_t4a(:t4a_tensor_new_structured_f64),
+                Cint,
+                (Csize_t, Ptr{Ptr{Cvoid}}, Ptr{Float64}, Csize_t, Ptr{Csize_t}, Csize_t, Ptr{Cptrdiff_t}, Csize_t, Ptr{Csize_t}, Csize_t, Ref{Ptr{Cvoid}}),
+                tensor_rank,
+                index_handles,
+                payload,
+                length(payload),
+                payload_dims,
+                length(payload_dims),
+                payload_strides,
+                length(payload_strides),
+                axis_classes,
+                length(axis_classes),
+                out,
+            )
+        elseif scalar_kind === :c64
+            payload = _core_interleaved_complex_data(storage.payload)
+            status = ccall(
+                _core_t4a(:t4a_tensor_new_structured_c64),
+                Cint,
+                (Csize_t, Ptr{Ptr{Cvoid}}, Ptr{Float64}, Csize_t, Ptr{Csize_t}, Csize_t, Ptr{Cptrdiff_t}, Csize_t, Ptr{Csize_t}, Csize_t, Ref{Ptr{Cvoid}}),
+                tensor_rank,
+                index_handles,
+                payload,
+                length(storage.payload),
+                payload_dims,
+                length(payload_dims),
+                payload_strides,
+                length(payload_strides),
+                axis_classes,
+                length(axis_classes),
+                out,
+            )
+        else
+            throw(ArgumentError("Unknown scalar kind $scalar_kind"))
+        end
+        _core_check_backend_status(status, "creating structured backend tensor")
+        return out[]
+    end
+    throw(ArgumentError("Unknown structured storage kind $(storage.kind)"))
+end
+
+function _core_new_tensor_handle_from_array(
+    data::Array,
+    indices::Vector{Index},
+    structured_storage::Union{Nothing,StructuredTensorStorage},
+)
+    scalar_kind = eltype(data) <: Real ? :f64 : eltype(data) <: Complex ? :c64 :
+        throw(ArgumentError("Tensor supports only real or complex arrays, got eltype $(eltype(data))"))
+    index_handles = Ptr{Cvoid}[]
+    try
+        for index in indices
+            push!(index_handles, _core_new_index_handle(index))
+        end
+        if structured_storage === nothing
+            return _core_new_dense_tensor_handle_from_array(data, indices, scalar_kind, index_handles)
+        end
+        return _core_new_structured_tensor_handle_from_storage(structured_storage, length(indices), scalar_kind, index_handles)
+    finally
+        for handle in index_handles
+            _core_release_index_handle(handle)
+        end
+    end
 end
 
 function _tensor_from_backend_handle(
@@ -106,7 +326,7 @@ function _tensor_from_backend_handle(
     length(indices) == N || throw(DimensionMismatch(
         "Tensor rank $N requires $N indices, got $(length(indices))",
     ))
-    return Tensor{T,N}(nothing, collect(indices), handle, structured_storage)
+    return Tensor{T,N}(handle, collect(indices))
 end
 
 function Tensor(
@@ -186,6 +406,28 @@ function _tensor_scalar_kind_from_owned_handle(handle)
     return out_kind[]
 end
 
+function _tensor_storage_kind_from_owned_handle(handle)
+    ptr = _backend_handle_ptr(handle)
+    ptr == C_NULL && throw(ArgumentError("Tensor has no backend handle"))
+    out_kind = Ref{Cint}(0)
+    status = ccall(
+        Libdl.dlsym(require_backend(), :t4a_tensor_storage_kind),
+        Cint,
+        (Ptr{Cvoid}, Ref{Cint}),
+        ptr,
+        out_kind,
+    )
+    _core_check_backend_status(status, "querying backend tensor storage kind")
+    return out_kind[]
+end
+
+function _core_storage_kind_symbol(kind::Cint)
+    kind == _CORE_T4A_STORAGE_KIND_DENSE && return :dense
+    kind == _CORE_T4A_STORAGE_KIND_DIAGONAL && return :diagonal
+    kind == _CORE_T4A_STORAGE_KIND_STRUCTURED && return :structured
+    throw(ArgumentError("Unsupported backend storage kind $kind"))
+end
+
 function _read_dense_f64_from_owned_handle(handle)
     ptr = _backend_handle_ptr(handle)
     out_len = Ref{Csize_t}(0)
@@ -212,6 +454,94 @@ function _read_dense_f64_from_owned_handle(handle)
     )
     status == _CORE_T4A_SUCCESS || throw(ArgumentError("copying backend dense tensor data failed"))
     return dense
+end
+
+function _read_core_cptrdiff_vector_from_handle(ptr::Ptr{Cvoid}, symbol::Symbol, context::AbstractString)
+    out_len = Ref{Csize_t}(0)
+    status = ccall(
+        Libdl.dlsym(require_backend(), symbol),
+        Cint,
+        (Ptr{Cvoid}, Ptr{Cptrdiff_t}, Csize_t, Ref{Csize_t}),
+        ptr,
+        C_NULL,
+        0,
+        out_len,
+    )
+    _core_check_backend_status(status, "querying backend tensor $context")
+
+    values = Vector{Cptrdiff_t}(undef, Int(out_len[]))
+    status = ccall(
+        Libdl.dlsym(require_backend(), symbol),
+        Cint,
+        (Ptr{Cvoid}, Ptr{Cptrdiff_t}, Csize_t, Ref{Csize_t}),
+        ptr,
+        values,
+        length(values),
+        out_len,
+    )
+    _core_check_backend_status(status, "copying backend tensor $context")
+    return Int.(values)
+end
+
+function _read_payload_f64_from_owned_handle(handle)
+    ptr = _backend_handle_ptr(handle)
+    out_len = Ref{Csize_t}(0)
+    status = ccall(
+        Libdl.dlsym(require_backend(), :t4a_tensor_copy_payload_f64),
+        Cint,
+        (Ptr{Cvoid}, Ptr{Float64}, Csize_t, Ref{Csize_t}),
+        ptr,
+        C_NULL,
+        0,
+        out_len,
+    )
+    _core_check_backend_status(status, "querying backend tensor payload data")
+
+    payload = Vector{Float64}(undef, Int(out_len[]))
+    status = ccall(
+        Libdl.dlsym(require_backend(), :t4a_tensor_copy_payload_f64),
+        Cint,
+        (Ptr{Cvoid}, Ptr{Float64}, Csize_t, Ref{Csize_t}),
+        ptr,
+        payload,
+        length(payload),
+        out_len,
+    )
+    _core_check_backend_status(status, "copying backend tensor payload data")
+    return payload
+end
+
+function _read_payload_c64_from_owned_handle(handle)
+    ptr = _backend_handle_ptr(handle)
+    out_len = Ref{Csize_t}(0)
+    status = ccall(
+        Libdl.dlsym(require_backend(), :t4a_tensor_copy_payload_c64),
+        Cint,
+        (Ptr{Cvoid}, Ptr{Float64}, Csize_t, Ref{Csize_t}),
+        ptr,
+        C_NULL,
+        0,
+        out_len,
+    )
+    _core_check_backend_status(status, "querying backend tensor payload data")
+
+    raw = Vector{Float64}(undef, 2 * Int(out_len[]))
+    status = ccall(
+        Libdl.dlsym(require_backend(), :t4a_tensor_copy_payload_c64),
+        Cint,
+        (Ptr{Cvoid}, Ptr{Float64}, Csize_t, Ref{Csize_t}),
+        ptr,
+        raw,
+        Int(out_len[]),
+        out_len,
+    )
+    _core_check_backend_status(status, "copying backend tensor payload data")
+
+    payload = Vector{ComplexF64}(undef, Int(out_len[]))
+    for n in eachindex(payload)
+        payload[n] = ComplexF64(raw[2n-1], raw[2n])
+    end
+    return payload
 end
 
 function _read_dense_c64_from_owned_handle(handle)
@@ -247,26 +577,14 @@ function _read_dense_c64_from_owned_handle(handle)
     return dense
 end
 
-function _materialize_tensor_data!(t::Tensor{T,N}) where {T,N}
-    data = getfield(t, :data)
-    data !== nothing && return data
-    handle = getfield(t, :backend_handle)
-    handle === nothing && throw(ArgumentError("Tensor has neither dense data nor backend handle"))
-    scalar_kind = _tensor_scalar_kind_from_owned_handle(handle)
-    dense = if scalar_kind == _CORE_T4A_SCALAR_KIND_F64
-        _read_dense_f64_from_owned_handle(handle)
-    elseif scalar_kind == _CORE_T4A_SCALAR_KIND_C64
-        _read_dense_c64_from_owned_handle(handle)
-    else
-        throw(ArgumentError("Unsupported backend tensor scalar kind $scalar_kind"))
-    end
-    materialized = convert(Array{T,N}, reshape(dense, dims(t)))
-    setfield!(t, :data, materialized)
-    return materialized
-end
-
 function Base.getproperty(t::Tensor, name::Symbol)
-    name === :data && return _materialize_tensor_data!(t)
+    name === :backend_handle && return getfield(t, :handle)
+    name === :data && throw(
+        ArgumentError("Tensor.data has been removed. Use copy_data(t) or Array(t) to materialize a fresh dense copy."),
+    )
+    name === :structured_storage && throw(
+        ArgumentError("Tensor.structured_storage has been removed. Use structured_storage_info(t) or structured_payload(t)."),
+    )
     return getfield(t, name)
 end
 
@@ -337,7 +655,40 @@ rank(t::Tensor) = length(t.inds)
 
 Return the logical dimensions of `t`.
 """
-dims(t::Tensor) = getfield(t, :data) === nothing ? _tensor_dims_from_owned_handle(getfield(t, :backend_handle)) : size(getfield(t, :data))
+dims(t::Tensor) = _tensor_dims_from_owned_handle(getfield(t, :handle))
+
+function _copy_data_from_handle(handle, ::Type{T}, ::Val{N}, tensor_dims::Tuple) where {T,N}
+    scalar_kind = _tensor_scalar_kind_from_owned_handle(handle)
+    dense = if scalar_kind == _CORE_T4A_SCALAR_KIND_F64
+        _read_dense_f64_from_owned_handle(handle)
+    elseif scalar_kind == _CORE_T4A_SCALAR_KIND_C64
+        _read_dense_c64_from_owned_handle(handle)
+    else
+        throw(ArgumentError("Unsupported backend tensor scalar kind $scalar_kind"))
+    end
+    return convert(Array{T,N}, reshape(dense, tensor_dims))
+end
+
+"""
+    copy_data(t::Tensor)
+    copy_data(t::Tensor, inds::Index...)
+
+Materialize `t` as a fresh dense Julia `Array`. Mutating the returned array
+does not mutate `t`. When indices are provided, the copy is returned in the
+requested index order.
+"""
+function copy_data(t::Tensor{T,N}) where {T,N}
+    return _copy_data_from_handle(getfield(t, :handle), T, Val(N), dims(t))
+end
+
+function copy_data(t::Tensor, requested_inds::Index...)
+    isempty(requested_inds) && return copy_data(t)
+    perm = _match_index_permutation(inds(t), collect(requested_inds))
+    data = copy_data(t)
+    return perm == Tuple(1:rank(t)) ? data : permutedims(data, perm)
+end
+
+copy_data(t::Tensor, requested_inds::AbstractVector{<:Index}) = copy_data(t, requested_inds...)
 
 """
     prime(t, n=1)
@@ -346,10 +697,9 @@ Return `t` with all attached indices primed by `n`.
 """
 function prime(t::Tensor, n::Integer=1)
     return Tensor(
-        copy(t.data),
+        copy_data(t),
         prime.(inds(t), Ref(n));
-        backend_handle=t.backend_handle,
-        structured_storage=_copy_structured_storage(t.structured_storage),
+        structured_storage=_structured_storage_from_tensor(t),
     )
 end
 
@@ -359,10 +709,9 @@ end
 Return the elementwise complex-conjugated tensor with the same index metadata.
 """
 dag(t::Tensor) = Tensor(
-    conj(t.data),
+    conj(copy_data(t)),
     inds(t);
-    backend_handle=nothing,
-    structured_storage=_map_structured_payload(conj, t.structured_storage),
+    structured_storage=_map_structured_payload(conj, _structured_storage_from_tensor(t)),
 )
 
 """
@@ -375,10 +724,9 @@ function swapinds(t::Tensor, a::Index, b::Index)
         idx == a ? b : idx == b ? a : idx
     end
     return Tensor(
-        copy(t.data),
+        copy_data(t),
         swapped;
-        backend_handle=t.backend_handle,
-        structured_storage=_copy_structured_storage(t.structured_storage),
+        structured_storage=_structured_storage_from_tensor(t),
     )
 end
 
@@ -389,10 +737,9 @@ Return a copy of `t` with index metadata `old` replaced by `new`.
 """
 function replaceind(t::Tensor, old::Index, new::Index)
     return Tensor(
-        t.data,
+        copy_data(t),
         replaceind(inds(t), old, new);
-        backend_handle=t.backend_handle,
-        structured_storage=_copy_structured_storage(t.structured_storage),
+        structured_storage=_structured_storage_from_tensor(t),
     )
 end
 
@@ -409,10 +756,9 @@ Return a copy of `t` with multiple index metadata replacements applied.
 """
 function replaceinds(t::Tensor, replacements::Pair{Index,Index}...)
     return Tensor(
-        t.data,
+        copy_data(t),
         replaceinds(inds(t), replacements...);
-        backend_handle=t.backend_handle,
-        structured_storage=_copy_structured_storage(t.structured_storage),
+        structured_storage=_structured_storage_from_tensor(t),
     )
 end
 
@@ -422,10 +768,9 @@ function replaceinds(
     newinds::AbstractVector{Index},
 )
     return Tensor(
-        t.data,
+        copy_data(t),
         replaceinds(inds(t), oldinds, newinds);
-        backend_handle=t.backend_handle,
-        structured_storage=_copy_structured_storage(t.structured_storage),
+        structured_storage=_structured_storage_from_tensor(t),
     )
 end
 
@@ -435,10 +780,9 @@ function replaceinds(
     newinds::Tuple{Vararg{Index}},
 )
     return Tensor(
-        t.data,
+        copy_data(t),
         replaceinds(inds(t), oldinds, newinds);
-        backend_handle=t.backend_handle,
-        structured_storage=_copy_structured_storage(t.structured_storage),
+        structured_storage=_structured_storage_from_tensor(t),
     )
 end
 
@@ -448,7 +792,7 @@ end
 Replace index metadata `old` by `new` in `t`.
 """
 function replaceind!(t::Tensor, old::Index, new::Index)
-    t.inds .= replaceind(t.inds, old, new)
+    _replace_tensor_indices_and_rebuild_handle!(t, replaceind(t.inds, old, new))
     return t
 end
 
@@ -464,7 +808,7 @@ replaceind!(t::Tensor, replacement::Pair{Index,Index}) = replaceind!(
 Apply multiple index metadata replacements in place to `t`.
 """
 function replaceinds!(t::Tensor, replacements::Pair{Index,Index}...)
-    t.inds .= replaceinds(t.inds, replacements...)
+    _replace_tensor_indices_and_rebuild_handle!(t, replaceinds(t.inds, replacements...))
     return t
 end
 
@@ -473,7 +817,7 @@ function replaceinds!(
     oldinds::AbstractVector{Index},
     newinds::AbstractVector{Index},
 )
-    t.inds .= replaceinds(t.inds, oldinds, newinds)
+    _replace_tensor_indices_and_rebuild_handle!(t, replaceinds(t.inds, oldinds, newinds))
     return t
 end
 
@@ -482,7 +826,17 @@ function replaceinds!(
     oldinds::Tuple{Vararg{Index}},
     newinds::Tuple{Vararg{Index}},
 )
-    t.inds .= replaceinds(t.inds, oldinds, newinds)
+    _replace_tensor_indices_and_rebuild_handle!(t, replaceinds(t.inds, oldinds, newinds))
+    return t
+end
+
+function _replace_tensor_indices_and_rebuild_handle!(t::Tensor{T,N}, newinds::AbstractVector{Index}) where {T,N}
+    data = copy_data(t)
+    storage = _structured_storage_from_tensor(t)
+    _validate_structured_storage(storage, size(data))
+    handle = TensorHandle(_core_new_tensor_handle_from_array(data, collect(newinds), storage))
+    t.inds .= newinds
+    t.handle = handle
     return t
 end
 
@@ -514,32 +868,31 @@ end
 
 function _permute_to_match(a::Tensor, b::Tensor)
     perm = _match_index_permutation(inds(b), inds(a))
-    return perm == Tuple(1:rank(a)) ? b.data : permutedims(b.data, perm)
+    data = copy_data(b)
+    return perm == Tuple(1:rank(a)) ? data : permutedims(data, perm)
 end
 
 function Base.:+(a::Tensor, b::Tensor)
     b_data = _permute_to_match(a, b)
-    return Tensor(a.data .+ b_data, inds(a); backend_handle=nothing)
+    return Tensor(copy_data(a) .+ b_data, inds(a))
 end
 
 function Base.:-(a::Tensor, b::Tensor)
     b_data = _permute_to_match(a, b)
-    return Tensor(a.data .- b_data, inds(a); backend_handle=nothing)
+    return Tensor(copy_data(a) .- b_data, inds(a))
 end
 
 Base.:-(t::Tensor) = Tensor(
-    -t.data,
+    -copy_data(t),
     inds(t);
-    backend_handle=nothing,
-    structured_storage=_map_structured_payload(-, t.structured_storage),
+    structured_storage=_map_structured_payload(-, _structured_storage_from_tensor(t)),
 )
 
 function Base.:*(α::Number, t::Tensor)
     return Tensor(
-        α .* t.data,
+        α .* copy_data(t),
         inds(t);
-        backend_handle=nothing,
-        structured_storage=_map_structured_payload(x -> α * x, t.structured_storage),
+        structured_storage=_map_structured_payload(x -> α * x, _structured_storage_from_tensor(t)),
     )
 end
 
@@ -548,30 +901,25 @@ Base.:*(a::Tensor, b::Tensor) = contract(a, b)
 
 function Base.:/(t::Tensor, α::Number)
     return Tensor(
-        t.data ./ α,
+        copy_data(t) ./ α,
         inds(t);
-        backend_handle=nothing,
-        structured_storage=_map_structured_payload(x -> x / α, t.structured_storage),
+        structured_storage=_map_structured_payload(x -> x / α, _structured_storage_from_tensor(t)),
     )
 end
 
-norm(t::Tensor) = norm(t.data)
+norm(t::Tensor) = norm(copy_data(t))
 
 function Base.isapprox(
     a::Tensor,
     b::Tensor;
     atol::Real=0,
-    rtol::Real=Base.rtoldefault(eltype(a.data), eltype(b.data), atol),
+    rtol::Real=Base.rtoldefault(eltype(a), eltype(b), atol),
 )
     b_data = _permute_to_match(a, b)
-    return isapprox(a.data, b_data; atol=atol, rtol=rtol)
+    return isapprox(copy_data(a), b_data; atol=atol, rtol=rtol)
 end
 
-function Base.Array(t::Tensor, requested_inds::Index...)
-    isempty(requested_inds) && rank(t) == 0 && return copy(t.data)
-    perm = _match_index_permutation(inds(t), collect(requested_inds))
-    return perm == Tuple(1:rank(t)) ? copy(t.data) : permutedims(t.data, perm)
-end
+Base.Array(t::Tensor, requested_inds::Index...) = copy_data(t, requested_inds...)
 
 function _copy_structured_storage(storage::Nothing)
     return nothing
@@ -584,6 +932,30 @@ function _copy_structured_storage(storage::StructuredTensorStorage{T}) where {T}
         copy(storage.payload_dims),
         copy(storage.payload_strides),
         copy(storage.axis_classes),
+    )
+end
+
+function _structured_storage_from_tensor(t::Tensor)
+    handle = getfield(t, :handle)
+    ptr = _backend_handle_ptr(handle)
+    storage_kind = _tensor_storage_kind_from_owned_handle(handle)
+    storage_kind == _CORE_T4A_STORAGE_KIND_DENSE && return nothing
+
+    scalar_kind = _tensor_scalar_kind_from_owned_handle(handle)
+    payload = if scalar_kind == _CORE_T4A_SCALAR_KIND_F64
+        _read_payload_f64_from_owned_handle(handle)
+    elseif scalar_kind == _CORE_T4A_SCALAR_KIND_C64
+        _read_payload_c64_from_owned_handle(handle)
+    else
+        throw(ArgumentError("Unsupported backend tensor scalar kind $scalar_kind"))
+    end
+
+    return StructuredTensorStorage{eltype(payload)}(
+        _core_storage_kind_symbol(storage_kind),
+        payload,
+        _read_core_csize_vector_from_handle(ptr, :t4a_tensor_payload_dims, "payload dimensions"),
+        _read_core_cptrdiff_vector_from_handle(ptr, :t4a_tensor_payload_strides, "payload strides"),
+        _read_core_csize_vector_from_handle(ptr, :t4a_tensor_axis_classes, "axis classes") .+ 1,
     )
 end
 
@@ -638,7 +1010,7 @@ end
 
 Return `true` when `t` is backed by compact diagonal storage metadata.
 """
-isdiag(t::Tensor) = t.structured_storage !== nothing && t.structured_storage.kind === :diagonal
+isdiag(t::Tensor) = _tensor_storage_kind_from_owned_handle(getfield(t, :handle)) == _CORE_T4A_STORAGE_KIND_DIAGONAL
 
 """
     structured_storage_info(t)
@@ -647,21 +1019,22 @@ Return storage metadata for `t` as a named tuple. `axis_classes` are reported
 with Julia's 1-based axis numbering.
 """
 function structured_storage_info(t::Tensor)
-    storage = t.structured_storage
+    storage = _structured_storage_from_tensor(t)
     if storage === nothing
+        data = copy_data(t)
         return (;
             kind=:dense,
-            dtype=eltype(t.data),
+            dtype=eltype(t),
             logical_dims=dims(t),
             payload_dims=dims(t),
-            payload_strides=Tuple(strides(t.data)),
-            payload_length=length(t.data),
+            payload_strides=Tuple(strides(data)),
+            payload_length=length(data),
             axis_classes=Tuple(1:rank(t)),
         )
     end
     return (;
         kind=storage.kind,
-        dtype=eltype(t.data),
+        dtype=eltype(t),
         logical_dims=dims(t),
         payload_dims=Tuple(storage.payload_dims),
         payload_strides=Tuple(storage.payload_strides),
@@ -677,8 +1050,8 @@ Return a copy of the compact storage payload for `t`. Dense tensors return
 their column-major dense payload.
 """
 function structured_payload(t::Tensor)
-    storage = t.structured_storage
-    storage === nothing && return vec(copy(t.data))
+    storage = _structured_storage_from_tensor(t)
+    storage === nothing && return vec(copy_data(t))
     return copy(storage.payload)
 end
 
@@ -699,7 +1072,7 @@ Return the scalar value stored in a rank-0 tensor.
 """
 function scalar(t::Tensor)
     rank(t) == 0 || throw(ArgumentError("scalar requires a rank-0 Tensor, got rank $(rank(t))"))
-    return only(t.data)
+    return only(copy_data(t))
 end
 
 struct OneHotTensor{T}
@@ -970,9 +1343,8 @@ function svd(
         v_inds = inds(v)
         s_inds = inds(s)
         v = Tensor(
-            copy(v.data),
-            replaceind(v_inds, last(v_inds), last(s_inds));
-            backend_handle=v.backend_handle,
+            copy_data(v),
+            replaceind(v_inds, last(v_inds), last(s_inds)),
         )
         return (u, s, v)
     finally

--- a/src/Core/Tensor.jl
+++ b/src/Core/Tensor.jl
@@ -19,6 +19,12 @@ mutable struct TensorHandle
     end
 end
 
+function Base.deepcopy_internal(::TensorHandle, ::IdDict)
+    throw(ArgumentError(
+        "TensorHandle cannot be deep-copied directly because it owns a backend pointer. Deep-copy the containing Tensor instead.",
+    ))
+end
+
 function _release_owned_tensor_handle(handle::TensorHandle)
     ptr = handle.ptr
     ptr == C_NULL && return nothing
@@ -920,6 +926,25 @@ function Base.isapprox(
 end
 
 Base.Array(t::Tensor, requested_inds::Index...) = copy_data(t, requested_inds...)
+
+function Base.copy(t::Tensor)
+    return Tensor(
+        copy_data(t),
+        inds(t);
+        structured_storage=_structured_storage_from_tensor(t),
+    )
+end
+
+function Base.deepcopy_internal(t::Tensor, stackdict::IdDict)
+    haskey(stackdict, t) && return stackdict[t]
+    result = Tensor(
+        copy_data(t),
+        Base.deepcopy_internal(getfield(t, :inds), stackdict);
+        structured_storage=_structured_storage_from_tensor(t),
+    )
+    stackdict[t] = result
+    return result
+end
 
 function _copy_structured_storage(storage::Nothing)
     return nothing

--- a/src/ITensorCompat.jl
+++ b/src/ITensorCompat.jl
@@ -87,7 +87,7 @@ Base.getindex(m::MPS, i::Int) = m.tt[i]
 Base.getindex(m::MPS, indices::AbstractVector{<:Integer}) = [m[Int(i)] for i in indices]
 Base.getindex(m::MPS, ::Colon) = [m[i] for i in eachindex(m)]
 Base.setindex!(m::MPS, tensor::Tensor, i::Int) = setindex!(m.tt, tensor, i)
-Base.eltype(m::MPS) = eltype(first(m.tt).data)
+Base.eltype(m::MPS) = eltype(first(m.tt))
 Base.IteratorEltype(::Type{MPS}) = Base.EltypeUnknown()
 
 siteinds(m::MPS) = _is_scalar_mps_train(m.tt) ? Index[] : [only(group) for group in TensorNetworks.siteinds(m.tt)]
@@ -321,7 +321,7 @@ Base.getindex(W::MPO, i::Int) = W.tt[i]
 Base.getindex(W::MPO, indices::AbstractVector{<:Integer}) = [W[Int(i)] for i in indices]
 Base.getindex(W::MPO, ::Colon) = [W[i] for i in eachindex(W)]
 Base.setindex!(W::MPO, tensor::Tensor, i::Int) = setindex!(W.tt, tensor, i)
-Base.eltype(W::MPO) = eltype(first(W.tt).data)
+Base.eltype(W::MPO) = eltype(first(W.tt))
 Base.IteratorEltype(::Type{MPO}) = Base.EltypeUnknown()
 
 siteinds(W::MPO) = TensorNetworks.siteinds(W.tt)

--- a/src/QuanticsTransform/QuanticsTransform.jl
+++ b/src/QuanticsTransform/QuanticsTransform.jl
@@ -1,7 +1,7 @@
 module QuanticsTransform
 
 import ..TensorNetworks
-using ..Tensor4all: Index, Tensor, dim, id, inds
+using ..Tensor4all: Index, Tensor, copy_data, dim, id, inds
 
 export shift_operator, shift_operator_multivar
 export flip_operator, flip_operator_multivar

--- a/src/QuanticsTransform/unfuse.jl
+++ b/src/QuanticsTransform/unfuse.jl
@@ -75,7 +75,7 @@ function _unfuse_tensor_indices(tensor::Tensor, replacements::Dict{Index, Vector
             append!(new_dims, dim.(replacement))
         end
     end
-    return Tensor(reshape(tensor.data, Tuple(new_dims)), new_indices)
+    return Tensor(reshape(copy_data(tensor), Tuple(new_dims)), new_indices)
 end
 
 function _restore_requested_site_indices!(

--- a/src/Tensor4all.jl
+++ b/src/Tensor4all.jl
@@ -46,7 +46,7 @@ export dot, inner, dist
 export linkind, linkinds, linkdims, siteind, siteinds
 export norm
 export orthogonalize, truncate
-export Tensor, ITensor, inds, rank, dims, swapinds, contract
+export Tensor, ITensor, inds, rank, dims, swapinds, copy_data, contract
 export delta, isdiag, structured_storage_info, structured_payload
 export selectinds, onehot, fixinds, suminds, projectinds
 export svd, qr

--- a/src/TensorNetworks.jl
+++ b/src/TensorNetworks.jl
@@ -7,7 +7,7 @@ import Random
 import Random: AbstractRNG
 import ScopedValues
 import ..Tensor4all: dag, contract, fixinds, suminds, projectinds
-using ..Tensor4all: BackendUnavailableError, Index, Tensor, TensorHandle, StructuredTensorStorage, SkeletonNotImplemented, _backend_handle_ptr, _normalize_tags, _tensor_from_backend_handle, commoninds, delta, dim, hastag, id, inds, plev, prime, rank, replaceinds!, require_backend, tags
+using ..Tensor4all: BackendUnavailableError, Index, Tensor, TensorHandle, StructuredTensorStorage, SkeletonNotImplemented, _backend_handle_ptr, _copy_structured_storage, _normalize_tags, _structured_storage_from_tensor, _tensor_from_backend_handle, commoninds, copy_data, delta, dim, hastag, id, inds, plev, prime, rank, replaceinds!, require_backend, tags
 import ..SimpleTT
 
 const _LINK_TAG = "Link"

--- a/src/TensorNetworks/backend/tensors.jl
+++ b/src/TensorNetworks/backend/tensors.jl
@@ -2,7 +2,7 @@ function _promoted_scalar_kind(tts::TensorTrain...)
     any_complex = false
     for tt in tts
         for tensor in tt.data
-            T = eltype(tensor.data)
+            T = eltype(tensor)
             if T <: Real
                 continue
             elseif T <: Complex
@@ -29,7 +29,8 @@ function _new_dense_tensor_handle(tensor::Tensor, scalar_kind::Symbol, index_han
     if scalar_kind === :f64
         # convert preserves array shape; broadcasting Float64.(arr) collapses
         # rank-0 arrays to a scalar, which then breaks the Ptr{Float64} ccall.
-        dense = convert(Array{Float64,ndims(tensor.data)}, tensor.data)
+        tensor_data = copy_data(tensor)
+        dense = convert(Array{Float64,ndims(tensor_data)}, tensor_data)
         return ccall(
             _t4a(:t4a_tensor_new_dense_f64),
             Cint,
@@ -41,7 +42,8 @@ function _new_dense_tensor_handle(tensor::Tensor, scalar_kind::Symbol, index_han
             out,
         )
     elseif scalar_kind === :c64
-        dense = _interleaved_complex_data(tensor.data)
+        tensor_data = copy_data(tensor)
+        dense = _interleaved_complex_data(tensor_data)
         return ccall(
             _t4a(:t4a_tensor_new_dense_c64),
             Cint,
@@ -49,7 +51,7 @@ function _new_dense_tensor_handle(tensor::Tensor, scalar_kind::Symbol, index_han
             rank(tensor),
             index_handles,
             dense,
-            length(tensor.data),
+            length(tensor_data),
             out,
         )
     end
@@ -202,7 +204,7 @@ function _new_tensor_handle(tensor::Tensor, scalar_kind::Symbol)
         end
 
         out = Ref{Ptr{Cvoid}}(C_NULL)
-        storage = tensor.structured_storage
+        storage = _structured_storage_from_tensor(tensor)
         if storage === nothing
             status = _new_dense_tensor_handle(tensor, scalar_kind, index_handles, out)
         else

--- a/src/TensorNetworks/backend/tensors.jl
+++ b/src/TensorNetworks/backend/tensors.jl
@@ -182,9 +182,16 @@ function _new_structured_tensor_handle(
     throw(ArgumentError("Unknown structured storage kind $(storage.kind)"))
 end
 
+function _scalar_kind_code(scalar_kind::Symbol)
+    scalar_kind === :f64 && return _T4A_SCALAR_KIND_F64
+    scalar_kind === :c64 && return _T4A_SCALAR_KIND_C64
+    throw(ArgumentError("Unknown scalar kind $scalar_kind"))
+end
+
 function _new_tensor_handle(tensor::Tensor, scalar_kind::Symbol)
     existing_handle = _backend_handle_ptr(tensor.backend_handle)
-    if existing_handle != C_NULL
+    if existing_handle != C_NULL &&
+            _tensor_scalar_kind_from_handle(existing_handle) == _scalar_kind_code(scalar_kind)
         out = Ref{Ptr{Cvoid}}(C_NULL)
         status = ccall(
             _t4a(:t4a_tensor_clone),

--- a/src/TensorNetworks/backend/treetn_dense.jl
+++ b/src/TensorNetworks/backend/treetn_dense.jl
@@ -48,5 +48,5 @@ function _restore_dense_site_metadata(tt::TensorTrain, tensor::Tensor)
         )
         return canonical
     end
-    return restored == inds(tensor) ? tensor : Tensor(tensor.data, restored)
+    return restored == inds(tensor) ? tensor : Tensor(copy_data(tensor), restored)
 end

--- a/src/TensorNetworks/identity_helpers.jl
+++ b/src/TensorNetworks/identity_helpers.jl
@@ -18,12 +18,14 @@ function _boundary_link(position::Integer)
 end
 
 function _prepend_link_axis(tensor::Tensor, link::Index)
-    data = reshape(tensor.data, 1, size(tensor.data)...)
+    tensor_data = copy_data(tensor)
+    data = reshape(tensor_data, 1, size(tensor_data)...)
     return Tensor(data, Index[link, inds(tensor)...])
 end
 
 function _append_link_axis(tensor::Tensor, link::Index)
-    data = reshape(tensor.data, size(tensor.data)..., 1)
+    tensor_data = copy_data(tensor)
+    data = reshape(tensor_data, size(tensor_data)..., 1)
     return Tensor(data, Index[inds(tensor)..., link])
 end
 

--- a/src/TensorNetworks/matchsiteinds.jl
+++ b/src/TensorNetworks/matchsiteinds.jl
@@ -90,7 +90,7 @@ function _resolve_mpo_sites(
 end
 
 function _canonicalize_mps_tensor(tensor::Tensor, sparse_position::Int, sparse_length::Int)
-    data = tensor.data
+    data = copy_data(tensor)
     if ndims(data) == 1
         sparse_length == 1 || throw(
             ArgumentError("Only single-site MPS-like TensorTrains may use rank-1 tensors"),
@@ -109,7 +109,7 @@ function _canonicalize_mps_tensor(tensor::Tensor, sparse_position::Int, sparse_l
 end
 
 function _canonicalize_mpo_tensor(tensor::Tensor, sparse_position::Int, sparse_length::Int)
-    data = tensor.data
+    data = copy_data(tensor)
     if ndims(data) == 2
         sparse_length == 1 || throw(
             ArgumentError("Only single-site MPO-like TensorTrains may use rank-2 tensors"),

--- a/src/TensorNetworks/operator_canonical.jl
+++ b/src/TensorNetworks/operator_canonical.jl
@@ -105,12 +105,13 @@ function _operator_canonical_tensor(
         ArgumentError("operator tensor $position has overlapping link/input/output axes"),
     )
 
-    data = length(source_axes) == ndims(tensor.data) ? permutedims(tensor.data, Tuple(source_axes)) :
-        tensor.data
-    if length(source_axes) != ndims(tensor.data)
+    tensor_data = copy_data(tensor)
+    data = length(source_axes) == ndims(tensor_data) ? permutedims(tensor_data, Tuple(source_axes)) :
+        tensor_data
+    if length(source_axes) != ndims(tensor_data)
         existing_axes = Set(source_axes)
         expected_missing = count(isnothing, (left_axis, right_axis))
-        ndims(tensor.data) - length(existing_axes) == 0 || throw(
+        ndims(tensor_data) - length(existing_axes) == 0 || throw(
             ArgumentError("operator tensor $position has unsupported extra axes"),
         )
         expected_missing in (1, 2) || throw(

--- a/src/TensorNetworks/site_helpers.jl
+++ b/src/TensorNetworks/site_helpers.jl
@@ -136,7 +136,7 @@ function _replace_tensor_indices(tensor::Tensor, replacements::Dict{Index, Index
         end
         return replacement
     end
-    return changed ? Tensor(tensor.data, new_indices; backend_handle=tensor.backend_handle) : tensor
+    return changed ? Tensor(copy_data(tensor), new_indices; structured_storage=_structured_storage_from_tensor(tensor)) : tensor
 end
 
 function _replace_tensor_indices!(tensor::Tensor, replacements::Dict{Index, Index})
@@ -165,12 +165,10 @@ function _replace_tensor_indices_keep_data(tensor::Tensor, replacements::Dict{In
     if !changed
         return tensor
     end
-    return Tensor{eltype(tensor.data),ndims(tensor.data)}(
-        tensor.data, new_indices, tensor.backend_handle, tensor.structured_storage
-    )
+    return Tensor(copy_data(tensor), new_indices; structured_storage=_structured_storage_from_tensor(tensor))
 end
 
-_copy_tensor(tensor::Tensor) = Tensor(tensor.data, inds(tensor); backend_handle=tensor.backend_handle)
+_copy_tensor(tensor::Tensor) = Tensor(copy_data(tensor), inds(tensor); structured_storage=_structured_storage_from_tensor(tensor))
 _copy_train(tt::TensorTrain) = TensorTrain([_copy_tensor(tensor) for tensor in tt.data], tt.llim, tt.rlim)
 
 """

--- a/src/TensorNetworks/transforms.jl
+++ b/src/TensorNetworks/transforms.jl
@@ -11,16 +11,17 @@ function _diagonalize_tensor_site(tensor::Tensor, site::Index)
     diagsite in tensor_indices && throw(
         ArgumentError("Tensor already contains diagonal partner $diagsite for site $site"),
     )
+    data = copy_data(tensor)
 
     new_dims = (
-        size(tensor.data)[1:site_axis-1]...,
+        size(data)[1:site_axis-1]...,
         dim(site),
         dim(site),
-        size(tensor.data)[site_axis+1:end]...,
+        size(data)[site_axis+1:end]...,
     )
-    diagonalized = zeros(eltype(tensor.data), new_dims...)
+    diagonalized = zeros(eltype(data), new_dims...)
 
-    for position in CartesianIndices(tensor.data)
+    for position in CartesianIndices(data)
         index_tuple = Tuple(position)
         diagonal_position = (
             index_tuple[1:site_axis-1]...,
@@ -28,14 +29,10 @@ function _diagonalize_tensor_site(tensor::Tensor, site::Index)
             index_tuple[site_axis],
             index_tuple[site_axis+1:end]...,
         )
-        diagonalized[diagonal_position...] = tensor.data[position]
+        diagonalized[diagonal_position...] = data[position]
     end
 
-    return Tensor(
-        diagonalized,
-        [tensor_indices[1:site_axis-1]..., diagsite, site, tensor_indices[site_axis+1:end]...];
-        backend_handle=tensor.backend_handle,
-    )
+    return Tensor(diagonalized, [tensor_indices[1:site_axis-1]..., diagsite, site, tensor_indices[site_axis+1:end]...])
 end
 
 function _extract_diagonal_tensor(tensor::Tensor, site::Index, diagsite::Index=prime(site))
@@ -49,10 +46,11 @@ function _extract_diagonal_tensor(tensor::Tensor, site::Index, diagsite::Index=p
 
     remaining_axes = [axis for axis in eachindex(tensor_indices) if axis != diag_axis]
     remaining_indices = tensor_indices[remaining_axes]
-    extracted = zeros(eltype(tensor.data), map(dim, remaining_indices)...)
+    data = copy_data(tensor)
+    extracted = zeros(eltype(data), map(dim, remaining_indices)...)
 
     for position in CartesianIndices(extracted)
-        old_position = Vector{Int}(undef, ndims(tensor.data))
+        old_position = Vector{Int}(undef, ndims(data))
         cursor = 1
         site_value = 0
         for axis in remaining_axes
@@ -63,10 +61,10 @@ function _extract_diagonal_tensor(tensor::Tensor, site::Index, diagsite::Index=p
             cursor += 1
         end
         old_position[diag_axis] = site_value
-        extracted[position] = tensor.data[Tuple(old_position)...]
+        extracted[position] = data[Tuple(old_position)...]
     end
 
-    return Tensor(extracted, remaining_indices; backend_handle=tensor.backend_handle)
+    return Tensor(extracted, remaining_indices)
 end
 
 """

--- a/test/core/tensor.jl
+++ b/test/core/tensor.jl
@@ -8,13 +8,21 @@ using LinearAlgebra: I
     data = reshape(collect(1.0:6.0), 2, 3)
     tensor = Tensor4all.Tensor(data, [i, j])
 
+    @test fieldnames(typeof(tensor)) == (:handle, :inds)
+    @test tensor.backend_handle !== nothing
     @test Tensor4all.rank(tensor) == 2
     @test Tensor4all.dims(tensor) == (2, 3)
     @test Tensor4all.inds(tensor) == [i, j]
     @test Tensor4all.inds(Tensor4all.prime(tensor)) == [Tensor4all.prime(i), Tensor4all.prime(j)]
     filled = Tensor4all.Tensor(4.0, i, j)
     @test Tensor4all.inds(filled) == [i, j]
-    @test filled.data == fill(4.0, 2, 3)
+    @test fieldnames(typeof(filled)) == (:handle, :inds)
+    @test filled.backend_handle !== nothing
+    @test Tensor4all.copy_data(filled) == fill(4.0, 2, 3)
+    filled_copy = Tensor4all.copy_data(filled)
+    @test filled_copy == fill(4.0, 2, 3)
+    filled_copy[1, 1] = -1.0
+    @test Tensor4all.copy_data(filled) == fill(4.0, 2, 3)
 
     bad = PermutedDimsArray(reshape(collect(1.0:8.0), 2, 2, 2), (2, 1, 3))
     k = Tensor4all.Index(2; tags=["k"])
@@ -23,8 +31,9 @@ using LinearAlgebra: I
     contracted = Tensor4all.contract(tensor, tensor)
     @test Tensor4all.rank(contracted) == 0
     @test Tensor4all.dims(contracted) == ()
-    @test contracted.data[] == 91.0
+    @test Tensor4all.copy_data(contracted)[] == 91.0
     @test only(Array(contracted)) == sum(data .* data)
+    @test only(Tensor4all.copy_data(contracted)) == sum(data .* data)
 end
 
 @testset "Tensor scalar and ITensor conveniences" begin
@@ -37,6 +46,25 @@ end
     @test_throws ArgumentError Tensor4all.scalar(t)
 end
 
+@testset "Tensor explicit materialization copies" begin
+    i = Index(2; tags=["i"])
+    j = Index(3; tags=["j"])
+    data = reshape(collect(1.0:6.0), 2, 3)
+    tensor = Tensor(data, [i, j])
+
+    copied = Tensor4all.copy_data(tensor)
+    @test copied == data
+    copied[1, 1] = -100.0
+    @test Tensor4all.copy_data(tensor) == data
+    @test Array(tensor) == data
+
+    reordered = Tensor4all.copy_data(tensor, j, i)
+    @test reordered == permutedims(data, (2, 1))
+    reordered[1, 1] = -200.0
+    @test Tensor4all.copy_data(tensor, j, i) == permutedims(data, (2, 1))
+    @test Tensor4all.copy_data(tensor, [j, i]) == permutedims(data, (2, 1))
+end
+
 @testset "Tensor replaceind compatibility" begin
     i = Tensor4all.Index(2; tags=["i"])
     j = Tensor4all.Index(3; tags=["j"])
@@ -46,14 +74,15 @@ end
     missing = Tensor4all.Index(2; tags=["missing"])
 
     data = reshape(collect(1.0:6.0), 2, 3)
-    handle = Ptr{Cvoid}(1)
-    tensor = Tensor4all.Tensor(data, [i, j]; backend_handle=handle)
+    tensor = Tensor4all.Tensor(data, [i, j])
+    handle = tensor.backend_handle
 
     replaced = Tensor4all.replaceind(tensor, i, ip)
     @test Tensor4all.inds(replaced) == [ip, j]
     @test Tensor4all.inds(tensor) == [i, j]
-    @test replaced.data == tensor.data
-    @test replaced.backend_handle == handle
+    @test Tensor4all.copy_data(replaced) == Tensor4all.copy_data(tensor)
+    @test replaced.backend_handle !== nothing
+    @test replaced.backend_handle != handle
 
     @test Tensor4all.inds(Tensor4all.replaceind(tensor, i => ip)) == [ip, j]
     @test Tensor4all.inds(Tensor4all.replaceinds(tensor, (i, j), (ip, jp))) == [ip, jp]
@@ -63,17 +92,21 @@ end
     @test_throws ArgumentError Tensor4all.replaceind(tensor, i, bad)
     @test_throws ArgumentError Tensor4all.replaceinds(tensor, (i,), (bad,))
 
-    mut = Tensor4all.Tensor(data, [i, j]; backend_handle=handle)
+    mut = Tensor4all.Tensor(data, [i, j])
+    mut_handle = mut.backend_handle
     @test Tensor4all.replaceind!(mut, i, ip) === mut
     @test Tensor4all.inds(mut) == [ip, j]
-    @test mut.data == data
-    @test mut.backend_handle == handle
+    @test Tensor4all.copy_data(mut) == data
+    @test mut.backend_handle !== nothing
+    @test mut.backend_handle != mut_handle
 
-    mut2 = Tensor4all.Tensor(data, [i, j]; backend_handle=handle)
+    mut2 = Tensor4all.Tensor(data, [i, j])
+    mut2_handle = mut2.backend_handle
     @test Tensor4all.replaceinds!(mut2, (i, j), (ip, jp)) === mut2
     @test Tensor4all.inds(mut2) == [ip, jp]
-    @test mut2.data == data
-    @test mut2.backend_handle == handle
+    @test Tensor4all.copy_data(mut2) == data
+    @test mut2.backend_handle !== nothing
+    @test mut2.backend_handle != mut2_handle
 end
 
 @testset "structured diagonal tensor payload metadata" begin
@@ -82,6 +115,8 @@ end
 
     d = Tensor4all.delta(i, j)
     @test Tensor4all.isdiag(d)
+    @test fieldnames(typeof(d)) == (:handle, :inds)
+    @test d.backend_handle !== nothing
 
     info = Tensor4all.structured_storage_info(d)
     @test info.kind == :diagonal

--- a/test/core/tensor.jl
+++ b/test/core/tensor.jl
@@ -65,6 +65,74 @@ end
     @test Tensor4all.copy_data(tensor, [j, i]) == permutedims(data, (2, 1))
 end
 
+@testset "Tensor copy ownership" begin
+    i = Index(2; tags=["i"])
+    j = Index(3; tags=["j"])
+    data = reshape(collect(1.0:6.0), 2, 3)
+    tensor = Tensor(data, [i, j])
+
+    ptr(t) = getfield(getfield(t, :handle), :ptr)
+
+    copied = copy(tensor)
+    @test copied !== tensor
+    @test ptr(copied) != ptr(tensor)
+    @test inds(copied) == inds(tensor)
+    @test copy_data(copied) == data
+
+    deepcopied = deepcopy(tensor)
+    @test deepcopied !== tensor
+    @test ptr(deepcopied) != ptr(tensor)
+    @test inds(deepcopied) == inds(tensor)
+    @test copy_data(deepcopied) == data
+
+    tt = Tensor4all.TensorNetworks.TensorTrain([tensor])
+    deep_tt = deepcopy(tt)
+    @test deep_tt !== tt
+    @test deep_tt.data[1] !== tt.data[1]
+    @test ptr(deep_tt.data[1]) != ptr(tt.data[1])
+    @test copy_data(deep_tt.data[1]) == data
+
+    shared_tt = Tensor4all.TensorNetworks.TensorTrain([tensor, tensor])
+    deep_shared_tt = deepcopy(shared_tt)
+    @test deep_shared_tt.data[1] === deep_shared_tt.data[2]
+    @test deep_shared_tt.data[1] !== tensor
+    @test ptr(deep_shared_tt.data[1]) != ptr(tensor)
+
+    op = Tensor4all.TensorNetworks.LinearOperator(;
+        mpo=tt,
+        input_indices=[i],
+        output_indices=[j],
+    )
+    deep_op = deepcopy(op)
+    @test deep_op !== op
+    @test deep_op.mpo !== op.mpo
+    @test ptr(deep_op.mpo.data[1]) != ptr(op.mpo.data[1])
+    @test copy_data(deep_op.mpo.data[1]) == data
+
+    scalar_mps = Tensor4all.ITensorCompat.MPS(
+        Tensor4all.TensorNetworks.TensorTrain([Tensor(2.0)]),
+    )
+    deep_mps = deepcopy(scalar_mps)
+    @test deep_mps !== scalar_mps
+    @test deep_mps.tt !== scalar_mps.tt
+    @test ptr(deep_mps.tt.data[1]) != ptr(scalar_mps.tt.data[1])
+    @test copy_data(deep_mps.tt.data[1])[] == 2.0
+
+    diag_tensor = delta(i, sim(i))
+    copied_diag = copy(diag_tensor)
+    deep_diag = deepcopy(diag_tensor)
+    @test isdiag(copied_diag)
+    @test isdiag(deep_diag)
+    @test ptr(copied_diag) != ptr(diag_tensor)
+    @test ptr(deep_diag) != ptr(diag_tensor)
+    @test structured_storage_info(copied_diag) == structured_storage_info(diag_tensor)
+    @test structured_storage_info(deep_diag) == structured_storage_info(diag_tensor)
+    @test structured_payload(copied_diag) == structured_payload(diag_tensor)
+    @test structured_payload(deep_diag) == structured_payload(diag_tensor)
+
+    @test_throws ArgumentError deepcopy(getfield(tensor, :handle))
+end
+
 @testset "Tensor replaceind compatibility" begin
     i = Tensor4all.Index(2; tags=["i"])
     j = Tensor4all.Index(3; tags=["j"])

--- a/test/core/tensor.jl
+++ b/test/core/tensor.jl
@@ -133,6 +133,20 @@ end
     @test_throws ArgumentError deepcopy(getfield(tensor, :handle))
 end
 
+@testset "Tensor backend handle scalar promotion" begin
+    i = Index(2; tags=["i"])
+    tensor = Tensor([1.0, 2.0], [i])
+
+    handle = Tensor4all.TensorNetworks._new_tensor_handle(tensor, :c64)
+    try
+        promoted = Tensor4all.TensorNetworks._tensor_from_handle(handle)
+        @test eltype(promoted) == ComplexF64
+        @test copy_data(promoted) == ComplexF64[1.0, 2.0]
+    finally
+        Tensor4all.TensorNetworks._release_tensor_handle(handle)
+    end
+end
+
 @testset "Tensor replaceind compatibility" begin
     i = Tensor4all.Index(2; tags=["i"])
     j = Tensor4all.Index(3; tags=["j"])

--- a/test/core/tensor_arithmetic.jl
+++ b/test/core/tensor_arithmetic.jl
@@ -13,37 +13,37 @@ using LinearAlgebra: norm
         b = Tensor(data_ij, [i, j])
         c = a + b
         @test inds(c) == [i, j]
-        @test c.data ≈ 2.0 .* data_ij
+        @test copy_data(c) ≈ 2.0 .* data_ij
     end
 
     @testset "addition permuted indices" begin
         b = Tensor(permutedims(data_ij, (2, 1)), [j, i])
         c = a + b
         @test inds(c) == [i, j]
-        @test c.data ≈ 2.0 .* data_ij
+        @test copy_data(c) ≈ 2.0 .* data_ij
     end
 
     @testset "subtraction" begin
         b = Tensor(data_ij, [i, j])
         c = a - b
-        @test c.data ≈ zeros(2, 3)
+        @test copy_data(c) ≈ zeros(2, 3)
     end
 
     @testset "unary negation" begin
         c = -a
-        @test c.data ≈ -data_ij
+        @test copy_data(c) ≈ -data_ij
     end
 
     @testset "scalar multiply" begin
         c = 3.0 * a
-        @test c.data ≈ 3.0 .* data_ij
+        @test copy_data(c) ≈ 3.0 .* data_ij
         c2 = a * 3.0
-        @test c2.data ≈ 3.0 .* data_ij
+        @test copy_data(c2) ≈ 3.0 .* data_ij
     end
 
     @testset "scalar divide" begin
         c = a / 2.0
-        @test c.data ≈ data_ij ./ 2.0
+        @test copy_data(c) ≈ data_ij ./ 2.0
     end
 
     @testset "norm" begin
@@ -74,6 +74,6 @@ using LinearAlgebra: norm
 
     @testset "complex scalars" begin
         c = (2.0 + 1.0im) * a
-        @test c.data ≈ (2.0 + 1.0im) .* data_ij
+        @test copy_data(c) ≈ (2.0 + 1.0im) .* data_ij
     end
 end

--- a/test/core/tensor_contract.jl
+++ b/test/core/tensor_contract.jl
@@ -13,7 +13,7 @@ using Tensor4all
         @test rank(result) == 1
         @test dims(result) == (2,)
         expected = reshape(collect(1.0:6.0), 2, 3) * collect(1.0:3.0)
-        @test result.data ≈ expected
+        @test copy_data(result) ≈ expected
     end
 
     @testset "matrix-matrix contraction" begin
@@ -22,7 +22,7 @@ using Tensor4all
         result = contract(A, B)
         @test rank(result) == 2
         expected = reshape(collect(1.0:6.0), 2, 3) * reshape(collect(1.0:12.0), 3, 4)
-        @test result.data ≈ expected
+        @test copy_data(result) ≈ expected
     end
 
     @testset "backend contraction result materializes lazily" begin
@@ -31,11 +31,16 @@ using Tensor4all
 
         result = contract(A, B)
 
-        @test getfield(result, :data) === nothing
+        @test fieldnames(typeof(result)) == (:handle, :inds)
         @test result.backend_handle !== nothing
         @test dims(result) == (2, 4)
+        materialized = Array(result, i, k)
+        @test materialized ≈ reshape(collect(1.0:6.0), 2, 3) * reshape(collect(1.0:12.0), 3, 4)
+        materialized[1, 1] = -1.0
         @test Array(result, i, k) ≈ reshape(collect(1.0:6.0), 2, 3) * reshape(collect(1.0:12.0), 3, 4)
-        @test getfield(result, :data) !== nothing
+        @test fieldnames(typeof(result)) == (:handle, :inds)
+        @test structured_storage_info(result).kind == :dense
+        @test fieldnames(typeof(result)) == (:handle, :inds)
     end
 
     @testset "selectinds fixes multiple indices lazily" begin
@@ -44,12 +49,15 @@ using Tensor4all
 
         selected = selectinds(t, j => 2, k => 3)
 
-        @test getfield(selected, :data) === nothing
+        @test fieldnames(typeof(selected)) == (:handle, :inds)
         @test selected.backend_handle !== nothing
         @test inds(selected) == [i]
         @test dims(selected) == (2,)
-        @test Array(selected, i) ≈ data[:, 2, 3]
-        @test getfield(selected, :data) !== nothing
+        selected_data = copy_data(selected, i)
+        @test selected_data ≈ data[:, 2, 3]
+        selected_data[1] = -1.0
+        @test copy_data(selected, i) ≈ data[:, 2, 3]
+        @test fieldnames(typeof(selected)) == (:handle, :inds)
     end
 
     @testset "outer product (no shared indices)" begin
@@ -58,7 +66,7 @@ using Tensor4all
         result = contract(a, b)
         @test rank(result) == 2
         @test inds(result) == [i, j]
-        @test result.data ≈ collect(1.0:2.0) * transpose(collect(1.0:3.0))
+        @test copy_data(result) ≈ collect(1.0:2.0) * transpose(collect(1.0:3.0))
     end
 
     @testset "index tags round-trip through backend with ITensors rules" begin

--- a/test/core/tensor_factorize.jl
+++ b/test/core/tensor_factorize.jl
@@ -13,10 +13,10 @@ using Tensor4all
     d = dag(t)
 
     @test inds(d) == [i, j]
-    @test d.data ≈ conj(data)
+    @test copy_data(d) ≈ conj(data)
 
     t_real = Tensor(reshape(collect(1.0:6.0), 2, 3), [i, j])
-    @test dag(t_real).data ≈ t_real.data
+    @test copy_data(dag(t_real)) ≈ copy_data(t_real)
 end
 
 @testset "Tensor Array with index reordering" begin
@@ -72,7 +72,7 @@ end
     _, S_explicit, _ = svd(t, [i];
         threshold=1e-6, svd_policy=TN.SvdTruncationPolicy())
     @test dims(S_default) == dims(S_explicit)
-    @test isapprox(S_default.data, S_explicit.data; atol=1e-14)
+    @test isapprox(copy_data(S_default), copy_data(S_explicit); atol=1e-14)
 
     # Strategy not covered by the default: absolute + squared + tail-sum.
     pol = TN.SvdTruncationPolicy(

--- a/test/extensions/hdf5_roundtrip.jl
+++ b/test/extensions/hdf5_roundtrip.jl
@@ -19,7 +19,7 @@ using HDF5
         @test tt2.llim == 0
         @test tt2.rlim == 2
         @test length(tt2) == 1
-        @test tt2.data[1].data == t.data
+        @test Tensor4all.copy_data(tt2.data[1]) == Tensor4all.copy_data(t)
         @test Tensor4all.inds(tt2.data[1]) == Tensor4all.inds(t)
 
         h5open(path, "r") do f
@@ -48,8 +48,8 @@ using HDF5
         @test length(tt2) == 2
         @test tt2.llim == 0
         @test tt2.rlim == 3
-        @test tt2.data[1].data == t1.data
-        @test tt2.data[2].data == t2.data
+        @test Tensor4all.copy_data(tt2.data[1]) == Tensor4all.copy_data(t1)
+        @test Tensor4all.copy_data(tt2.data[2]) == Tensor4all.copy_data(t2)
 
         h5open(path, "r") do f
             g = f["psi"]

--- a/test/itensorcompat/bubbleteaci_workflow.jl
+++ b/test/itensorcompat/bubbleteaci_workflow.jl
@@ -15,10 +15,10 @@ const TN_BTCI = Tensor4all.TensorNetworks
 
     replacement = Index(2; tags=["y", "y=1"])
     original_first = m[1]
-    original_data = m[1].data
+    original_data = copy_data(m[1])
     @test IC_BTCI.replace_siteinds!(m, [sites[1]], [replacement]) === m
     @test m[1] === original_first
-    @test m[1].data === original_data
+    @test copy_data(m[1]) == original_data
     @test IC_BTCI.siteinds(m)[1] == replacement
 
     dummy = Index(2; tags=["dummy", "dummy=1"])

--- a/test/itensorcompat/operator_overloads.jl
+++ b/test/itensorcompat/operator_overloads.jl
@@ -78,7 +78,7 @@ end
 
     filled = ITensor(2.5, sites[1], sites[2])
     @test Tensor4all.inds(filled) == sites[1:2]
-    @test filled.data == fill(2.5, 2, 2)
+    @test Tensor4all.copy_data(filled) == fill(2.5, 2, 2)
 
     rng = MersenneTwister(7)
     r = IC.random_itensor(rng, ComplexF64, sites[1], sites[2])
@@ -178,7 +178,7 @@ end
     mp = IC.prime(m)
     @test IC.siteinds(mp)[1].plev == 1
     @test IC.siteinds(m)[1].plev == 0  # original unchanged
-    @test mp[1].data === m[1].data     # tensor data shared
+    @test copy_data(mp[1]) == copy_data(m[1])
 
     IC.prime!(m)
     @test IC.siteinds(m)[1].plev == 1

--- a/test/tensornetworks/apply.jl
+++ b/test/tensornetworks/apply.jl
@@ -36,6 +36,11 @@ function single_site_operator(internal_input::Index, internal_output::Index, mat
     return TN.LinearOperator(; mpo, input_indices=[internal_input], output_indices=[internal_output])
 end
 
+function single_site_operator(internal_input::Index, internal_output::Index, matrix::Matrix{ComplexF64})
+    mpo = TN.TensorTrain([Tensor(matrix, [internal_output, internal_input])], 0, 2)
+    return TN.LinearOperator(; mpo, input_indices=[internal_input], output_indices=[internal_output])
+end
+
 function apply_matrix_on_last_axis(data::AbstractMatrix, matrix::AbstractMatrix)
     expected = similar(data)
     for row in axes(data, 1), out in axes(matrix, 1)
@@ -77,4 +82,18 @@ end
     pol = TN.SvdTruncationPolicy()
     result_pol = TN.apply(op, state; threshold=1e-12, svd_policy=pol)
     @test tn_test_dense_tensor(result_pol, output_true) ≈ tn_test_dense_tensor(state, input_sites)
+
+    complex_matrix = ComplexF64[0.0 1.0 + 0.5im; 2.0 - 1.0im 0.0]
+    complex_partial = single_site_operator(internal_in, internal_out, complex_matrix)
+    complex_output = Index(2; tags=["zcomplex", "zcomplex=2"])
+    TN.set_iospaces!(complex_partial, [input_sites[2]], [complex_output])
+
+    complex_result = TN.apply(complex_partial, state)
+    expected_complex = apply_matrix_on_last_axis(
+        ComplexF64.(tn_test_dense_tensor(state, input_sites)),
+        complex_matrix,
+    )
+
+    @test eltype(complex_result.data[1]) == ComplexF64
+    @test tn_test_dense_tensor(complex_result, [input_sites[1], complex_output]) ≈ expected_complex
 end

--- a/test/tensornetworks/arithmetic.jl
+++ b/test/tensornetworks/arithmetic.jl
@@ -69,10 +69,10 @@ function _tt_arith_dense_contract(
 end
 
 function tt_arith_dense_tensor(tt::TN.TensorTrain, target_inds::Vector{Index})
-    data = copy(tt[1].data)
+    data = Tensor4all.copy_data(tt[1])
     current_inds = inds(tt[1])
     for n in 2:length(tt)
-        data, current_inds = _tt_arith_dense_contract(data, current_inds, tt[n].data, inds(tt[n]))
+        data, current_inds = _tt_arith_dense_contract(data, current_inds, Tensor4all.copy_data(tt[n]), inds(tt[n]))
     end
 
     boundary_axes = [axis for (axis, index) in pairs(current_inds) if hastag(index, "Link")]

--- a/test/tensornetworks/arithmetic.jl
+++ b/test/tensornetworks/arithmetic.jl
@@ -225,6 +225,26 @@ end
         @test TN.siteinds(result_truncated) == TN.siteinds(tt1)
         @test length.(TN.siteinds(result_truncated)) == [2, 2, 2]
     end
+
+    @testset "mixed real and complex addition promotes backend handles" begin
+        s1 = Index(2; tags=["mix", "s=1"])
+        s2 = Index(2; tags=["mix", "s=2"])
+        link = Index(2; tags=["Link", "mix-l=1"])
+        real_tt = TN.TensorTrain([
+            Tensor(reshape([1.0, 2.0, 3.0, 4.0], 2, 2), [s1, link]),
+            Tensor(reshape([5.0, 6.0, 7.0, 8.0], 2, 2), [link, s2]),
+        ])
+        complex_tt = TN.TensorTrain([
+            Tensor(ComplexF64.(reshape([1.0, 0.0, 0.0, 1.0], 2, 2)), [s1, link]),
+            Tensor(ComplexF64.(reshape([2.0, 3.0, 4.0, 5.0], 2, 2)), [link, s2]),
+        ])
+
+        result = TN.add(real_tt, complex_tt)
+        @test eltype(result.data[1]) == ComplexF64
+        @test tt_arith_dense_tensor(result, [s1, s2]) ≈
+            tt_arith_dense_tensor(real_tt, [s1, s2]) .+
+            tt_arith_dense_tensor(complex_tt, [s1, s2])
+    end
 end
 
 @testset "TensorTrain truncated add" begin
@@ -258,6 +278,14 @@ end
     @test abs(imag(self_dot)) < 1e-10
 
     @test TensorNetworks.inner(tt1, tt2) ≈ d
+
+    @testset "mixed real and complex dot promotes backend handles" begin
+        real_tt, _, dense = make_known_two_site_mps()
+        complex_tt = (1.0 + 0.25im) * real_tt
+        mixed_dot = TensorNetworks.dot(real_tt, complex_tt)
+        @test mixed_dot ≈ sum(conj.(dense) .* ((1.0 + 0.25im) .* dense))
+        @test TensorNetworks.inner(real_tt, complex_tt) ≈ mixed_dot
+    end
 end
 
 @testset "TensorTrain norm" begin

--- a/test/tensornetworks/contract.jl
+++ b/test/tensornetworks/contract.jl
@@ -49,7 +49,7 @@ using Random: MersenneTwister
         # dense forms (this avoids the rank-0 to_dense path which currently
         # mishandles rank-0 inputs in _new_tensor_handle).
         expected = Tensor4all.contract(TN_CONTRACT.to_dense(a), TN_CONTRACT.to_dense(b))
-        @test result.data[1].data[] ≈ expected.data[]
+        @test Tensor4all.copy_data(result.data[1])[] ≈ Tensor4all.copy_data(expected)[]
     end
 
     @testset "MPS · MPO leaves output sites" begin

--- a/test/tensornetworks/contract.jl
+++ b/test/tensornetworks/contract.jl
@@ -91,6 +91,22 @@ using Random: MersenneTwister
         @test result_dense ≈ expected
     end
 
+    @testset "mixed real and complex inputs promote backend handles" begin
+        sites = [Index(2; tags=["mix-contract", "s=$n"]) for n in 1:2]
+        links_a = [Index(2; tags=["LinkA", "mix-contract=1"])]
+        links_b = [Index(2; tags=["LinkB", "mix-contract=1"])]
+        real_tt = _make_mps(sites, links_a, Float64; seed=70)
+        complex_tt = _make_mps(sites, links_b, ComplexF64; seed=80)
+
+        result = TN_CONTRACT.contract(real_tt, complex_tt)
+        expected = Tensor4all.contract(
+            TN_CONTRACT.to_dense(real_tt),
+            TN_CONTRACT.to_dense(complex_tt),
+        )
+        @test eltype(result.data[1]) == ComplexF64
+        @test copy_data(result.data[1])[] ≈ copy_data(expected)[]
+    end
+
     @testset "argument validation" begin
         sites = [Index(2; tags=["s", "s=$n"]) for n in 1:2]
         links = [Index(2; tags=["L", "l=1"])]

--- a/test/tensornetworks/dense.jl
+++ b/test/tensornetworks/dense.jl
@@ -66,13 +66,13 @@ end
         tt = TN_DENSE.TensorTrain([Tensor(fill(3.5), Index[])])
         dense = TN_DENSE.to_dense(tt)
         @test rank(dense) == 0
-        @test dense.data[] ≈ 3.5
+        @test Tensor4all.copy_data(dense)[] ≈ 3.5
 
         # Complex scalar
         tt_c = TN_DENSE.TensorTrain([Tensor(fill(ComplexF64(3.5 + 1.0im)), Index[])])
         dense_c = TN_DENSE.to_dense(tt_c)
         @test rank(dense_c) == 0
-        @test dense_c.data[] ≈ 3.5 + 1.0im
+        @test Tensor4all.copy_data(dense_c)[] ≈ 3.5 + 1.0im
     end
 
     @testset "rank-0 result from full MPS contraction (regression for #47)" begin
@@ -92,7 +92,7 @@ end
         @test rank(dense) == 0
         # Compare to direct tensor-tensor contraction of the dense forms.
         expected = Tensor4all.contract(TN_DENSE.to_dense(a), TN_DENSE.to_dense(b))
-        @test dense.data[] ≈ expected.data[]
+        @test Tensor4all.copy_data(dense)[] ≈ Tensor4all.copy_data(expected)[]
     end
 
     @testset "three-site MPO" begin

--- a/test/tensornetworks/dense.jl
+++ b/test/tensornetworks/dense.jl
@@ -43,6 +43,19 @@ end
         @test result ≈ expected
     end
 
+    @testset "mixed real and complex sites promote backend handles" begin
+        s1 = Index(2; tags=["k", "mixed=1"])
+        s2 = Index(2; tags=["k", "mixed=2"])
+        link = Index(2; tags=["Link", "mixed-link=1"])
+        tt = TN_DENSE.TensorTrain([
+            Tensor([1.0 0.0; 0.0 1.0], [s1, link]),
+            Tensor(ComplexF64[2.0 0.0; 0.0 1.0im], [link, s2]),
+        ])
+        result = TN_DENSE.to_dense(tt)
+        @test eltype(result) == ComplexF64
+        @test copy_data(result, s1, s2) ≈ ComplexF64[2.0 0.0; 0.0 1.0im]
+    end
+
     @testset "norm round-trip" begin
         tt, expected = _dense_two_site_mps_real()
         dense = TN_DENSE.to_dense(tt)

--- a/test/tensornetworks/dense_helpers.jl
+++ b/test/tensornetworks/dense_helpers.jl
@@ -37,10 +37,10 @@ end
 
 if !isdefined(@__MODULE__, :tn_test_dense_tensor)
     function tn_test_dense_tensor(tt::TN.TensorTrain, target_inds::Vector{Index})
-        data = copy(tt[1].data)
+        data = copy_data(tt[1])
         current_inds = inds(tt[1])
         for n in 2:length(tt)
-            data, current_inds = _tn_test_dense_contract(data, current_inds, tt[n].data, inds(tt[n]))
+            data, current_inds = _tn_test_dense_contract(data, current_inds, copy_data(tt[n]), inds(tt[n]))
         end
 
         boundary_axes = [axis for (axis, index) in pairs(current_inds) if hastag(index, "Link")]

--- a/test/tensornetworks/evaluate.jl
+++ b/test/tensornetworks/evaluate.jl
@@ -60,6 +60,20 @@ end
         @test v ≈ dense[2, 2]
     end
 
+    @testset "mixed real and complex sites promote backend handles" begin
+        s1 = Index(2; tags=["s", "mixed=1"])
+        s2 = Index(2; tags=["s", "mixed=2"])
+        link = Index(2; tags=["L", "mixed=1"])
+        tt = TN_EVAL.TensorTrain([
+            Tensor([1.0 0.5; 0.0 1.0], [s1, link]),
+            Tensor(ComplexF64[2.0 0.0; 0.0 1.0 + 1.0im], [link, s2]),
+        ])
+        dense = Array(TN_EVAL.to_dense(tt), [s1, s2]...)
+        v = TN_EVAL.evaluate(tt, [s1, s2], [2, 2])
+        @test v ≈ dense[2, 2]
+        @test v isa ComplexF64
+    end
+
     @testset "argument validation" begin
         tt, sites = _eval_two_site_mps()
         empty_tt = TN_EVAL.TensorTrain(Tensor[])

--- a/test/tensornetworks/matchsiteinds.jl
+++ b/test/tensornetworks/matchsiteinds.jl
@@ -4,7 +4,7 @@ using Tensor4all
 const TN = Tensor4all.TensorNetworks
 
 function canonical_mps_tensor(tensor::Tensor, position::Int, length_tt::Int)
-    data = tensor.data
+    data = copy_data(tensor)
     if ndims(data) == 1
         return Array(reshape(copy(data), 1, size(data, 1), 1))
     elseif ndims(data) == 2
@@ -20,7 +20,7 @@ function canonical_mps_tensor(tensor::Tensor, position::Int, length_tt::Int)
 end
 
 function canonical_mpo_tensor(tensor::Tensor, position::Int, length_tt::Int)
-    data = tensor.data
+    data = copy_data(tensor)
     if ndims(data) == 2
         return Array(reshape(copy(data), 1, size(data, 1), size(data, 2), 1))
     elseif ndims(data) == 3

--- a/test/tensornetworks/queries.jl
+++ b/test/tensornetworks/queries.jl
@@ -59,7 +59,7 @@ using Tensor4all
         tt_c = TensorNetworks.TensorTrain([tc])
         tt_d = TensorNetworks.dag(tt_c)
         @test inds(tt_d[1]) == inds(tc)
-        @test tt_d[1].data ≈ conj(tc.data)
+        @test Tensor4all.copy_data(tt_d[1]) ≈ conj(Tensor4all.copy_data(tc))
         @test length(tt_d) == 1
     end
 end

--- a/test/tensornetworks/random.jl
+++ b/test/tensornetworks/random.jl
@@ -41,7 +41,7 @@ const TN_RANDOM = Tensor4all.TensorNetworks
     @testset "complex eltype" begin
         sites = [Index(2; tags=["s", "s=$i"]) for i in 1:4]
         tt = TN_RANDOM.random_tt(ComplexF64, sites; linkdims=3)
-        @test eltype(tt[2].data) == ComplexF64
+        @test eltype(Tensor4all.copy_data(tt[2])) == ComplexF64
         @test TN_RANDOM.norm(tt) ≈ 1.0
     end
 
@@ -50,7 +50,7 @@ const TN_RANDOM = Tensor4all.TensorNetworks
         tt1 = TN_RANDOM.random_tt(MersenneTwister(42), sites; linkdims=2)
         tt2 = TN_RANDOM.random_tt(MersenneTwister(42), sites; linkdims=2)
         for j in 1:length(tt1)
-            @test tt1[j].data == tt2[j].data
+            @test Tensor4all.copy_data(tt1[j]) == Tensor4all.copy_data(tt2[j])
         end
     end
 

--- a/test/tensornetworks/transform_helpers.jl
+++ b/test/tensornetworks/transform_helpers.jl
@@ -46,7 +46,7 @@ function simple_mps(sites::Vector{Index})
             data = reshape(collect(cursor:(cursor + elements - 1)), dim(links[i - 1]), dim(sites[i]), dim(links[i]))
             push!(tensors, Tensor(data, [links[i - 1], sites[i], links[i]]))
         end
-        cursor += length(tensors[end].data)
+        cursor += length(copy_data(tensors[end]))
     end
     return TN.TensorTrain(tensors, 0, n + 1)
 end


### PR DESCRIPTION
## Summary

Closes #91.
Fixes #94.
Fixes #95.

This changes `Tensor` from a dense-data-first object into a backend-handle owner. A `Tensor` now stores only the backend `TensorHandle` and Julia-side `Index` metadata; dense materialization is explicit through `copy_data(t)`, `copy_data(t, inds...)`, or `Array(t, inds...)`.

## Changes

- Add and export `copy_data` as the explicit dense materialization API with fresh-copy semantics.
- Remove `data` and `structured_storage` fields from `Tensor`; `.data` and `.structured_storage` now throw actionable migration errors.
- Make `Tensor(data, inds)` create the backend tensor handle immediately.
- Query structured storage metadata and payload from the backend instead of cached Tensor fields.
- Add safe `copy(::Tensor)` and `deepcopy(::Tensor)` semantics that rebuild independently owned backend handles.
- Reject direct `deepcopy(::TensorHandle)` to avoid duplicating ownership of one raw Rust pointer.
- Honor requested scalar promotion in `_new_tensor_handle(tensor, scalar_kind)` instead of cloning an f64 backend handle into promoted c64 TensorTrain operations.
- Update Core, TensorNetworks, ITensorCompat, and QuanticsTransform internals to use `copy_data` where dense materialization is required.
- Document FFI handle ownership rules in `REPOSITORY_RULES.md`.
- Update tests to assert fresh-copy behavior, handle ownership safety, and mixed real/complex promotion across `add`, `dot`, `contract`, `apply`, `to_dense`, and `evaluate`.

## Root Cause Notes

- #94: Julia's default `deepcopy` recursively copied the `TensorHandle` wrapper while preserving the same raw Rust tensor pointer, creating duplicated ownership and possible dangling pointers or double release after GC.
- #95: TensorTrain operations computed a promoted scalar kind, but `_new_tensor_handle` cloned existing backend handles without checking whether the handle already had the requested scalar kind. Real blocks therefore stayed f64 inside mixed real/complex operations.

## Validation

- `env JULIA_NUM_THREADS=1 JULIA_NUM_GC_THREADS=1 OPENBLAS_NUM_THREADS=1 BLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 RAYON_NUM_THREADS=1 TENSOR4ALL_NUM_THREADS=1 T4A_SKIP_HDF5_TESTS=1 julia --startup-file=no --project=. test/runtests.jl`
- `env JULIA_NUM_THREADS=1 JULIA_NUM_GC_THREADS=1 OPENBLAS_NUM_THREADS=1 BLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 RAYON_NUM_THREADS=1 TENSOR4ALL_NUM_THREADS=1 T4A_SKIP_HDF5_TESTS=1 julia --startup-file=no --project=. -e 'using Test; using Tensor4all; include("test/core/tensor.jl"); include("test/tensornetworks/arithmetic.jl"); include("test/tensornetworks/contract.jl"); include("test/tensornetworks/apply.jl"); include("test/tensornetworks/dense.jl"); include("test/tensornetworks/evaluate.jl")'`
- `git diff --check`
- Earlier in this PR: `scripts/check_autodocs_coverage.jl` and `docs/make.jl` passed. Documenter still emits the existing `api.html` size warning, but exits successfully.
