### PR TITLE
Added InterpolativeQTT

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["tensor4all collaboration"]
 
 [deps]
+InterpolativeQTT = "87f1ea11-1d4d-47cb-b1d1-07788fc25290"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 QuanticsGrids = "634c7f73-3e90-4749-a1bd-001b8efc642d"
@@ -21,6 +22,7 @@ Tensor4allHDF5Ext = ["HDF5"]
 
 [compat]
 HDF5 = "0.17"
+InterpolativeQTT = "0.1"
 QuanticsGrids = "0.7"
 QuanticsTCI = "0.7.3"
 RustToolChain = "0.1"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -306,6 +306,7 @@ Order = [:function]
 
 - `Tensor4all.QuanticsGrids` re-exports the public `QuanticsGrids.jl` surface
 - `Tensor4all.QuanticsTCI` re-exports the public `QuanticsTCI.jl` surface
+- `Tensor4all.InterpolativeQTT` re-exports the public `InterpolativeQTT.jl` surface
 
 These modules are wrapper re-exports for discoverability. Tensor4all does not
 take ownership of their APIs; see the upstream
@@ -335,6 +336,22 @@ qtt, ranks, errors = QTCI.quanticscrossinterpolate(
 
 qtt(4)      # evaluate at an integer grid index
 sum(qtt)    # upstream QuanticsTCI reduction
+```
+
+[InterpolativeQTT.jl docs](https://tensor4all.github.io/InterpolativeQTT.jl/dev)
+
+```julia
+const IQTT = Tensor4all.InterpolativeQTT
+
+# single-scale Chebyshev QTT approximation
+tt = IQTT.interpolatesinglescale(x -> exp(-x^2), -2.0, 2.0, 8, 20)
+```
+
+```@autodocs
+Modules = [Tensor4all.InterpolativeQTT]
+Pages = ["InterpolativeQTT.jl"]
+Private = false
+Order = [:type, :function]
 ```
 
 ## HDF5 Compatibility

--- a/docs/superpowers/plans/2026-05-10-interpolativeqtt-integration.md
+++ b/docs/superpowers/plans/2026-05-10-interpolativeqtt-integration.md
@@ -1,0 +1,390 @@
+# InterpolativeQTT Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Integrate InterpolativeQTT.jl into Tensor4all.jl as `Tensor4all.InterpolativeQTT`, re-exporting the eight QTT interpolation symbols using the same pattern as `Tensor4all.QuanticsGrids`.
+
+**Architecture:** Add curated `export` statements to InterpolativeQTT.jl upstream, register it in the General Registry, then add it as a dependency of Tensor4all.jl and create a thin re-export wrapper module — identical in structure to `src/QuanticsGrids.jl`.
+
+**Tech Stack:** Julia 1.9+, TensorCrossInterpolation.jl (already a shared dependency), Documenter.jl.
+
+---
+
+## Cross-repo Sequencing
+
+Tasks 1–2 target the **InterpolativeQTT.jl** repo. Tasks 3–7 target **Tensor4all.jl**. Do not open the Tensor4all.jl PR until InterpolativeQTT.jl is merged **and** registered in the General Registry.
+
+## File Map
+
+| File | Action |
+|------|--------|
+| `InterpolativeQTT.jl/src/InterpolativeQTT.jl` | Modify — add 8 export statements |
+| `Tensor4all.jl/src/InterpolativeQTT.jl` | Create — re-export wrapper module |
+| `Tensor4all.jl/src/Tensor4all.jl` | Modify — import, include, export |
+| `Tensor4all.jl/Project.toml` | Modify — add dep + compat entry |
+| `Tensor4all.jl/test/interpolativeqtt/surface.jl` | Create — surface + functional tests |
+| `Tensor4all.jl/test/runtests.jl` | Modify — include new test file |
+| `Tensor4all.jl/docs/src/api.md` | Modify — add InterpolativeQTT section |
+
+---
+
+## Task 1: Add exports to InterpolativeQTT.jl
+
+**Repo:** `InterpolativeQTT.jl`
+
+**Files:**
+- Modify: `src/InterpolativeQTT.jl`
+
+- [ ] **Step 1.1: Write the failing export test**
+
+Create `test/exports.jl` in the InterpolativeQTT.jl repo:
+
+```julia
+using Test
+import InterpolativeQTT
+
+@testset "exported symbols" begin
+    exported = names(InterpolativeQTT)
+    for sym in [
+        :LagrangePolynomials, :getChebyshevGrid,
+        :interpolatesinglescale, :interpolatemultiscale, :interpolateadaptive,
+        :interpolatesinglescale_sparse, :invertqtt, :estimate_interpolation_error,
+    ]
+        @test sym ∈ exported
+    end
+    for sym in [:Interval, :NInterval, :midpoint, :intervallength, :angular_local_lagrange]
+        @test sym ∉ exported
+    end
+end
+```
+
+- [ ] **Step 1.2: Run test to confirm it fails**
+
+```bash
+cd path/to/InterpolativeQTT.jl
+env JULIA_NUM_THREADS=1 JULIA_NUM_GC_THREADS=1 OPENBLAS_NUM_THREADS=1 \
+    BLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 RAYON_NUM_THREADS=1 \
+    julia --startup-file=no --project=. test/exports.jl
+```
+
+Expected: test failures — none of the 8 symbols are in `names(InterpolativeQTT)`.
+
+- [ ] **Step 1.3: Add exports to `src/InterpolativeQTT.jl`**
+
+Open `src/InterpolativeQTT.jl`. Insert these lines immediately after the `module InterpolativeQTT` line, before the first `import`/`using`:
+
+```julia
+export LagrangePolynomials, getChebyshevGrid
+export interpolatesinglescale, interpolatemultiscale, interpolateadaptive
+export interpolatesinglescale_sparse
+export invertqtt, estimate_interpolation_error
+```
+
+The file should now begin:
+
+```julia
+module InterpolativeQTT
+
+export LagrangePolynomials, getChebyshevGrid
+export interpolatesinglescale, interpolatemultiscale, interpolateadaptive
+export interpolatesinglescale_sparse
+export invertqtt, estimate_interpolation_error
+
+import TensorCrossInterpolation as TCI
+using LinearAlgebra
+
+import Base: in
+
+include("interval.jl")
+include("interpolation.jl")
+include("angular_lagrange.jl")
+
+end
+```
+
+- [ ] **Step 1.4: Run test to confirm it passes**
+
+```bash
+env JULIA_NUM_THREADS=1 JULIA_NUM_GC_THREADS=1 OPENBLAS_NUM_THREADS=1 \
+    BLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 RAYON_NUM_THREADS=1 \
+    julia --startup-file=no --project=. test/exports.jl
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 1.5: Commit and open PR**
+
+```bash
+git add src/InterpolativeQTT.jl test/exports.jl
+git commit -m "feat: export public QTT interpolation surface"
+```
+
+Open a PR in the InterpolativeQTT.jl repo. Merge it. Then register the package in the Julia General Registry (open a PR to [JuliaRegistries/General](https://github.com/JuliaRegistries/General) using the `Registrator.jl` bot or `LocalRegistry`). **Wait for registration to complete before proceeding to Task 2.**
+
+---
+
+## Task 2: Register InterpolativeQTT.jl as a dependency in Tensor4all.jl
+
+**Repo:** `Tensor4all.jl`
+
+**Files:**
+- Modify: `Project.toml`
+
+Once InterpolativeQTT.jl v0.1.1 is registered in the General Registry, add it to Tensor4all.jl:
+
+- [ ] **Step 2.1: Add the dependency**
+
+```bash
+cd path/to/Tensor4all.jl
+env JULIA_NUM_THREADS=1 JULIA_NUM_GC_THREADS=1 OPENBLAS_NUM_THREADS=1 \
+    BLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 RAYON_NUM_THREADS=1 \
+    julia --startup-file=no --project=. -e "using Pkg; Pkg.add(\"InterpolativeQTT\")"
+```
+
+> **During local development before registration:** replace the above with
+> `Pkg.develop(path="path/to/InterpolativeQTT.jl")` to use a local checkout.
+> Switch to the registered version (`Pkg.add`) once registration is complete.
+
+- [ ] **Step 2.2: Verify `Project.toml` now contains**
+
+```toml
+[deps]
+# ... existing deps ...
+InterpolativeQTT = "87f1ea11-1d4d-47cb-b1d1-07788fc25290"
+
+[compat]
+# ... existing compat ...
+InterpolativeQTT = "0.1"
+```
+
+If the `Pkg.add` did not add a `[compat]` entry, add it manually.
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+git add Project.toml Manifest.toml
+git commit -m "deps: add InterpolativeQTT.jl dependency"
+```
+
+---
+
+## Task 3: Write the failing surface and functional tests
+
+**Files:**
+- Create: `test/interpolativeqtt/surface.jl`
+- Modify: `test/runtests.jl`
+
+- [ ] **Step 3.1: Create `test/interpolativeqtt/surface.jl`**
+
+```julia
+using Test
+using Tensor4all
+import TensorCrossInterpolation as TCI
+
+@testset "InterpolativeQTT surface" begin
+    @test isdefined(Tensor4all, :InterpolativeQTT)
+    @test :InterpolativeQTT ∉ Tensor4all.InterpolativeQTT._reexportable_symbols()
+
+    for sym in [
+        :LagrangePolynomials, :getChebyshevGrid,
+        :interpolatesinglescale, :interpolatemultiscale, :interpolateadaptive,
+        :interpolatesinglescale_sparse, :invertqtt, :estimate_interpolation_error,
+    ]
+        @test isdefined(Tensor4all.InterpolativeQTT, sym)
+    end
+
+    for sym in [:Interval, :NInterval, :angular_local_lagrange]
+        @test !isdefined(Tensor4all.InterpolativeQTT, sym)
+    end
+end
+
+@testset "InterpolativeQTT functional" begin
+    IQTT = Tensor4all.InterpolativeQTT
+
+    f = x -> exp(-x^2)
+    tt = IQTT.interpolatesinglescale(f, -2.0, 2.0, 8, 20)
+    @test tt isa TCI.TensorTrain{Float64, 3}
+    @test length(tt) == 8
+
+    P = IQTT.getChebyshevGrid(5)
+    @test P isa IQTT.LagrangePolynomials{Float64}
+    @test length(P.grid) == 6
+end
+```
+
+- [ ] **Step 3.2: Add the include to `test/runtests.jl`**
+
+Add this line at the end of `test/runtests.jl`, before the HDF5 block:
+
+```julia
+include("interpolativeqtt/surface.jl")
+```
+
+- [ ] **Step 3.3: Run tests to confirm they fail**
+
+```bash
+env JULIA_NUM_THREADS=1 JULIA_NUM_GC_THREADS=1 OPENBLAS_NUM_THREADS=1 \
+    BLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 RAYON_NUM_THREADS=1 \
+    julia --startup-file=no --project=. test/runtests.jl 2>&1 | grep -A5 "InterpolativeQTT"
+```
+
+Expected: `UndefVarError: InterpolativeQTT not defined` or similar.
+
+---
+
+## Task 4: Create the re-export wrapper and wire it in
+
+**Files:**
+- Create: `src/InterpolativeQTT.jl`
+- Modify: `src/Tensor4all.jl`
+
+- [ ] **Step 4.1: Create `src/InterpolativeQTT.jl`**
+
+```julia
+module InterpolativeQTT
+
+import ..UpstreamInterpolativeQTT
+
+function _reexportable_symbols()
+    return filter(names(UpstreamInterpolativeQTT)) do sym
+        sym !== nameof(UpstreamInterpolativeQTT) &&
+            Base.isidentifier(sym) &&
+            sym ∉ (:eval, :include)
+    end
+end
+
+for sym in _reexportable_symbols()
+    @eval const $(sym) = getfield(UpstreamInterpolativeQTT, $(QuoteNode(sym)))
+    @eval export $(sym)
+end
+
+end
+```
+
+- [ ] **Step 4.2: Modify `src/Tensor4all.jl`**
+
+Add the upstream import alongside the existing ones (after `import QuanticsTCI as UpstreamQuanticsTCI`):
+
+```julia
+import InterpolativeQTT as UpstreamInterpolativeQTT
+```
+
+Add the include alongside the other submodule includes (after `include("QuanticsTCI.jl")`):
+
+```julia
+include("InterpolativeQTT.jl")
+```
+
+Add `InterpolativeQTT` to the export list at the bottom of the file (alongside `QuanticsGrids`, `QuanticsTCI`, etc.):
+
+```julia
+export TensorNetworks, ITensorCompat, SimpleTT, TensorCI, QuanticsGrids, QuanticsTCI, QuanticsTransform, InterpolativeQTT
+```
+
+- [ ] **Step 4.3: Run the full test suite to confirm the new tests pass**
+
+```bash
+env JULIA_NUM_THREADS=1 JULIA_NUM_GC_THREADS=1 OPENBLAS_NUM_THREADS=1 \
+    BLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 RAYON_NUM_THREADS=1 \
+    julia --startup-file=no --project=. test/runtests.jl
+```
+
+Expected: all tests pass, including the two new `InterpolativeQTT` testsets.
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+git add src/InterpolativeQTT.jl src/Tensor4all.jl test/interpolativeqtt/surface.jl test/runtests.jl
+git commit -m "feat: add Tensor4all.InterpolativeQTT re-export module"
+```
+
+---
+
+## Task 5: Update `docs/src/api.md`
+
+**Files:**
+- Modify: `docs/src/api.md`
+
+- [ ] **Step 5.1: Extend the Adopted Modules section**
+
+Find the `## Adopted Modules` section in `docs/src/api.md`. It currently covers QuanticsGrids and QuanticsTCI. Add the InterpolativeQTT entry to the opening bullet list and append an `@autodocs` block.
+
+Replace the existing `## Adopted Modules` section with:
+
+```markdown
+## Adopted Modules
+
+- `Tensor4all.QuanticsGrids` re-exports the public `QuanticsGrids.jl` surface
+- `Tensor4all.QuanticsTCI` re-exports the public `QuanticsTCI.jl` surface
+- `Tensor4all.InterpolativeQTT` re-exports the public `InterpolativeQTT.jl` surface
+
+These modules are wrapper re-exports for discoverability. Tensor4all does not
+take ownership of their APIs; see the upstream docs for the complete surface.
+
+[QuanticsGrids.jl docs](https://tensor4all.org/QuanticsGrids.jl/dev/apireference/)
+[QuanticsTCI.jl docs](https://tensor4all.org/QuanticsTCI.jl/dev/apireference/)
+[InterpolativeQTT.jl docs](https://tensor4all.github.io/InterpolativeQTT.jl/dev)
+
+```julia
+const QG = Tensor4all.QuanticsGrids
+
+grid = QG.DiscretizedGrid(3, 0.0, 1.0)
+grid_index = QG.origcoord_to_grididx(grid, 0.5)
+quantics_index = QG.grididx_to_quantics(grid, grid_index)
+QG.quantics_to_origcoord(grid, quantics_index)  # 0.5
+```
+
+```julia
+const QTCI = Tensor4all.QuanticsTCI
+
+qtt, ranks, errors = QTCI.quanticscrossinterpolate(
+    Float64,
+    x -> sin(x),
+    range(0, 1; length=8);
+    tolerance=1e-8,
+)
+
+qtt(4)      # evaluate at an integer grid index
+sum(qtt)    # upstream QuanticsTCI reduction
+```
+
+```julia
+const IQTT = Tensor4all.InterpolativeQTT
+
+tt = IQTT.interpolatesinglescale(x -> exp(-x^2), -2.0, 2.0, 8, 20)
+```
+
+```@autodocs
+Modules = [Tensor4all.InterpolativeQTT]
+Pages = ["InterpolativeQTT.jl"]
+Private = false
+Order = [:type, :function]
+```
+```
+
+- [ ] **Step 5.2: Verify the docs build cleanly**
+
+```bash
+env JULIA_NUM_THREADS=1 JULIA_NUM_GC_THREADS=1 OPENBLAS_NUM_THREADS=1 \
+    BLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 RAYON_NUM_THREADS=1 \
+    julia --startup-file=no --project=docs docs/make.jl
+```
+
+Expected: no errors, no warnings about missing docstrings.
+
+- [ ] **Step 5.3: Run autodocs coverage check**
+
+```bash
+env JULIA_NUM_THREADS=1 JULIA_NUM_GC_THREADS=1 OPENBLAS_NUM_THREADS=1 \
+    BLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 RAYON_NUM_THREADS=1 \
+    julia --startup-file=no --project=. scripts/check_autodocs_coverage.jl
+```
+
+Expected: exits 0 with no missing pages reported.
+
+- [ ] **Step 5.4: Commit**
+
+```bash
+git add docs/src/api.md
+git commit -m "docs: add InterpolativeQTT to api.md Adopted Modules section"
+```

--- a/docs/superpowers/specs/2026-05-10-interpolativeqtt-integration-design.md
+++ b/docs/superpowers/specs/2026-05-10-interpolativeqtt-integration-design.md
@@ -1,0 +1,124 @@
+# InterpolativeQTT.jl Integration Design
+
+**Date:** 2026-05-10
+**Status:** Approved
+
+## Goal
+
+Integrate [InterpolativeQTT.jl](https://github.com/tensor4all/InterpolativeQTT.jl) into
+Tensor4all.jl as a re-export module (`Tensor4all.InterpolativeQTT`), following the same
+pattern as `Tensor4all.QuanticsGrids` and `Tensor4all.QuanticsTCI`.
+
+## Background
+
+InterpolativeQTT.jl implements multiscale polynomial (Chebyshev) interpolation for
+quantics tensor trains (QTTs), based on Lindsey arXiv:2311.12554. It currently has no
+`export` statements, so the standard `names()`-based re-export loop used elsewhere in
+Tensor4all.jl would produce nothing without upstream changes.
+
+## Chosen Approach
+
+**Approach A — Curated exports upstream + standard re-export loop.**
+
+Add exactly eight `export` statements to InterpolativeQTT.jl covering the user-facing
+QTT interpolation surface. The Tensor4all wrapper then uses a `names()` loop identical
+to QuanticsGrids.jl. Authority over the public surface lives in the upstream package.
+
+Rejected alternatives:
+- **Approach B** (no upstream exports, explicit list in wrapper): keeps upstream
+  unchanged but duplicates the symbol list in Tensor4all and makes the wrapper diverge
+  from the established pattern.
+- **Approach C** (export everything upstream, filter in wrapper): risks leaking internal
+  symbols if the upstream package grows.
+
+## Exported Surface
+
+The following eight symbols are exported from InterpolativeQTT.jl and re-exported from
+`Tensor4all.InterpolativeQTT`:
+
+| Symbol | Kind |
+|--------|------|
+| `LagrangePolynomials` | type |
+| `getChebyshevGrid` | function |
+| `interpolatesinglescale` | function |
+| `interpolatemultiscale` | function |
+| `interpolateadaptive` | function |
+| `interpolatesinglescale_sparse` | function |
+| `invertqtt` | function |
+| `estimate_interpolation_error` | function |
+
+Not re-exported: `Interval`, `NInterval`, `midpoint`, `split`, `intervallength`,
+`angular_local_lagrange` (internal interval machinery and implementation helpers).
+
+## Implementation Plan
+
+### Step 1 — InterpolativeQTT.jl (upstream PR, merged first)
+
+Add to `src/InterpolativeQTT.jl` before the `include` calls:
+
+```julia
+export LagrangePolynomials, getChebyshevGrid
+export interpolatesinglescale, interpolatemultiscale, interpolateadaptive
+export interpolatesinglescale_sparse
+export invertqtt, estimate_interpolation_error
+```
+
+Merge this PR and note the commit hash. Register InterpolativeQTT.jl in the Julia
+General Registry. Pin the registered version in Tensor4all.jl only after registration
+is complete.
+
+### Step 2 — New file `src/InterpolativeQTT.jl` in Tensor4all.jl
+
+```julia
+module InterpolativeQTT
+
+import ..UpstreamInterpolativeQTT
+
+function _reexportable_symbols()
+    return filter(names(UpstreamInterpolativeQTT)) do sym
+        sym !== nameof(UpstreamInterpolativeQTT) &&
+            Base.isidentifier(sym) &&
+            sym ∉ (:eval, :include)
+    end
+end
+
+for sym in _reexportable_symbols()
+    @eval const $(sym) = getfield(UpstreamInterpolativeQTT, $(QuoteNode(sym)))
+    @eval export $(sym)
+end
+
+end
+```
+
+### Step 3 — `Project.toml`
+
+- Add `InterpolativeQTT` under `[deps]` with its UUID (`87f1ea11-1d4d-47cb-b1d1-07788fc25290`).
+- Add `InterpolativeQTT = "0.1"` under `[compat]`.
+
+### Step 4 — `src/Tensor4all.jl`
+
+- Add `import InterpolativeQTT as UpstreamInterpolativeQTT` alongside the existing
+  upstream imports.
+- Add `include("InterpolativeQTT.jl")` alongside the other submodule includes.
+- Add `InterpolativeQTT` to the `export` list at the bottom.
+
+### Step 5 — `docs/src/api.md`
+
+Append `"InterpolativeQTT.jl"` to the `Pages = [...]` list in the relevant `@autodocs`
+block so `scripts/check_autodocs_coverage.jl` stays green.
+
+## Cross-repo Sequencing
+
+Per AGENTS.md cross-repo development rules:
+
+1. Develop and test the InterpolativeQTT.jl export PR locally.
+2. Merge the InterpolativeQTT.jl PR.
+3. Register InterpolativeQTT.jl in the General Registry; wait for registration.
+4. Update `[compat]` pin in Tensor4all.jl to the registered version.
+5. Open the Tensor4all.jl PR.
+
+## Out of Scope
+
+- No custom method wrappers or overrides at the Tensor4all boundary.
+- No re-export of interval types or Base method extensions (`in`, `split`).
+- No changes to `TensorNetworks`, `SimpleTT`, or any other Tensor4all submodule.

--- a/src/InterpolativeQTT.jl
+++ b/src/InterpolativeQTT.jl
@@ -1,0 +1,18 @@
+module InterpolativeQTT
+
+import ..UpstreamInterpolativeQTT
+
+function _reexportable_symbols()
+    return filter(names(UpstreamInterpolativeQTT)) do sym
+        sym !== nameof(UpstreamInterpolativeQTT) &&
+            Base.isidentifier(sym) &&
+            sym ∉ (:eval, :include)
+    end
+end
+
+for sym in _reexportable_symbols()
+    @eval const $(sym) = getfield(UpstreamInterpolativeQTT, $(QuoteNode(sym)))
+    @eval export $(sym)
+end
+
+end

--- a/src/Tensor4all.jl
+++ b/src/Tensor4all.jl
@@ -14,6 +14,7 @@ using LinearAlgebra: norm
 import LinearAlgebra
 import QuanticsGrids as UpstreamQuanticsGrids
 import QuanticsTCI as UpstreamQuanticsTCI
+import InterpolativeQTT as UpstreamInterpolativeQTT
 
 const SKELETON_PHASE = true
 
@@ -30,6 +31,7 @@ include("ITensorCompat.jl")
 include("TensorCI.jl")
 include("QuanticsGrids.jl")
 include("QuanticsTCI.jl")
+include("InterpolativeQTT.jl")
 include("QuanticsTransform/QuanticsTransform.jl")
 
 using .TensorNetworks: add, apply, dot, inner, dist, linkdims, linkind, linkinds, siteinds, orthogonalize, truncate
@@ -53,6 +55,6 @@ export delta, isdiag, structured_storage_info, structured_payload
 export selectinds, onehot, fixinds, suminds, projectinds
 export svd, qr
 export random_itensor, random_mps
-export TensorNetworks, ITensorCompat, SimpleTT, TensorCI, QuanticsGrids, QuanticsTCI, QuanticsTransform
+export TensorNetworks, ITensorCompat, SimpleTT, TensorCI, QuanticsGrids, QuanticsTCI, QuanticsTransform, InterpolativeQTT
 
 end

--- a/test/interpolativeqtt/surface.jl
+++ b/test/interpolativeqtt/surface.jl
@@ -1,0 +1,33 @@
+using Test
+using Tensor4all
+import TensorCrossInterpolation as TCI
+
+@testset "InterpolativeQTT surface" begin
+    @test isdefined(Tensor4all, :InterpolativeQTT)
+    @test :InterpolativeQTT ∉ Tensor4all.InterpolativeQTT._reexportable_symbols()
+
+    for sym in [
+        :LagrangePolynomials, :getChebyshevGrid,
+        :interpolatesinglescale, :interpolatemultiscale, :interpolateadaptive,
+        :interpolatesinglescale_sparse, :invertqtt, :estimate_interpolation_error,
+    ]
+        @test isdefined(Tensor4all.InterpolativeQTT, sym)
+    end
+
+    for sym in [:Interval, :NInterval, :angular_local_lagrange]
+        @test !isdefined(Tensor4all.InterpolativeQTT, sym)
+    end
+end
+
+@testset "InterpolativeQTT functional" begin
+    IQTT = Tensor4all.InterpolativeQTT
+
+    f = x -> exp(-x^2)
+    tt = IQTT.interpolatesinglescale(f, -2.0, 2.0, 8, 20)
+    @test tt isa TCI.TensorTrain{Float64, 3}
+    @test length(tt) == 8
+
+    P = IQTT.getChebyshevGrid(5)
+    @test P isa IQTT.LagrangePolynomials{Float64}
+    @test length(P.grid) == 6
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,6 +43,7 @@ include("itensorcompat/bubbleteaci_workflow.jl")
 include("itensorcompat/operator_overloads.jl")
 include("quanticsgrids/surface.jl")
 include("quanticstci/surface.jl")
+include("interpolativeqtt/surface.jl")
 if get(ENV, "T4A_SKIP_HDF5_TESTS", "0") != "1" && Base.find_package("HDF5") !== nothing
     include("extensions/hdf5_roundtrip.jl")
 end


### PR DESCRIPTION
## Summary

This PR adds InterpolativeQTT.jl as a dependency and re-exports all public QTT interpolation functions via a new `Tensor4all.InterpolativeQTT` module, following the same pattern as `Tensor4all.QuanticsGrids` and `Tensor4all.QuanticsTCI`.

The following symbols are re-exported:
- `interpolatesinglescale`, `interpolatemultiscale`, `interpolateadaptive`, `interpolatesinglescale_sparse`
- `invertqtt`, `estimate_interpolation_error`
- `LagrangePolynomials`, `getChebyshevGrid`
## Checklist

- [ ] Related issue is linked above
- [x] `Pkg.test()` passes
- [x] `julia --project=docs docs/make.jl` runs cleanly (if exported symbols changed)
- [x] If a new `src/**/*.jl` file defines public symbols, it is listed in some `@autodocs` `Pages = [...]` block in `docs/src/api.md` (verified by `scripts/check_autodocs_coverage.jl`)
- [ ] `README.md` updated (if public API or workflow changed)
